### PR TITLE
fix(reader): rotate display for left-handed mode

### DIFF
--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -274,11 +274,22 @@ void App::renderScreen(uint32_t nowMs) {
         }
         break;
     }
-    case screens::Screen::ReaderSettings:
+    case screens::Screen::ReaderSettings: {
         immediateUi_.beginFrame(static_cast<uint8_t>(screen_));
-        if (screens::readerSettings(immediateUi_, settingsStore_.settings().reading, screen_))
+        const bool leftHanded = settingsStore_.settings().reading.leftHanded;
+        if (screens::readerSettings(immediateUi_, settingsStore_.settings().reading, screen_)) {
             settingsStore_.acceptChanges();
+            if (leftHanded != settingsStore_.settings().reading.leftHanded) {
+                immediateUi_.endFrame();
+                immediateUi_.setOrientation(settingsStore_.settings().reading.leftHanded
+                                                ? Board::Display::rotatedUiOrientation()
+                                                : Board::Display::defaultUiOrientation());
+                renderScreen(nowMs);
+                return;
+            }
+        }
         break;
+    }
     case screens::Screen::NetworkSettings:
         immediateUi_.beginFrame(static_cast<uint8_t>(screen_));
         action = networkScreen_.draw(immediateUi_, settingsStore_, screen_);
@@ -837,6 +848,8 @@ void App::applySettings() {
 void App::loadAppearanceSettings() {
     auto& current = settingsStore_.settings();
     bool corrected = false;
+    immediateUi_.setOrientation(current.reading.leftHanded ? Board::Display::rotatedUiOrientation()
+                                                           : Board::Display::defaultUiOrientation());
     immediateUi_.setLanguageCatalog(storage_.mounted() ? &Board::Storage::filesystem() : nullptr, &localeCatalog_,
                                     &locales::loadUiFont);
     if (!readerScreen_.fonts.find(current.reading.typography.fontId)) {

--- a/src/companion/http/CompanionSettingsApi.cpp
+++ b/src/companion/http/CompanionSettingsApi.cpp
@@ -41,9 +41,15 @@ api::Result<> CompanionApi::patchReadingSettings(httpd_req_t& request) {
                     settingsStore_.settings().reading)
         .transform([this](settings::ReadingSettings reading) {
             reading.typography.fontId = settingsStore_.settings().reading.typography.fontId;
+            const bool leftHanded = settingsStore_.settings().reading.leftHanded;
             settingsStore_.settings().reading = std::move(reading);
             settingsStore_.acceptChanges();
             readerScreen_.releaseRuntimeCaches();
+            if (leftHanded != settingsStore_.settings().reading.leftHanded) {
+                ui_.setOrientation(settingsStore_.settings().reading.leftHanded
+                                       ? Board::Display::rotatedUiOrientation()
+                                       : Board::Display::defaultUiOrientation());
+            }
         });
 }
 


### PR DESCRIPTION
Closes #163. Applies the board-specific flipped orientation when left-handed mode is loaded or changed, including companion updates, without setting orientation on every app iteration. Validation: 48 focused UI tests and LCD 3.49 rev1/rev2 firmware builds pass.