### PR TITLE
ci(web): deploy Pages on web-related main changes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,22 @@
 name: Pages
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'companion/apps/web/**'
+      - 'companion/shared/**'
+      - 'companion/conversion/**'
+      - 'companion/build-logic/**'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'gradlew'
+      - 'gradle/**'
+      - 'kotlin-js-store/wasm/**'
+      - 'tools/fetch_release_firmware.py'
+      - 'tools/export_web_firmware.py'
+      - '.github/workflows/pages.yml'
   workflow_run:
     workflows: [Release firmware]
     types: [completed]


### PR DESCRIPTION
Deploy the website when web-related changes land on main, without requiring a firmware release. The push filter covers the web app, shared companion and conversion modules, build logic, Gradle configuration, Wasm dependency lockfile, firmware-packaging scripts, and the Pages workflow itself. Existing release-completion and manual triggers remain available.

Validation: parsed the workflow YAML, checked the main-only push trigger and preserved triggers, and passed git diff --check.
