### PR TITLE
fix(library): update cached listing after book deletion

### DIFF
--- a/docs/releases/v0.1.1.md
+++ b/docs/releases/v0.1.1.md
@@ -1,0 +1,4 @@
+# v0.1.1
+
+- Update the Nano's cached library after deleting a book instead of rescanning
+  the card after every deletion. Other books retain their cached metadata.

--- a/src/library/StorageManager.cpp
+++ b/src/library/StorageManager.cpp
@@ -93,7 +93,8 @@ std::expected<void, std::error_code> StorageManager::installBook(std::string_vie
 std::expected<void, std::error_code> StorageManager::removeBook(std::string_view path) {
     if (!mounted_)
         return std::unexpected(std::make_error_code(std::errc::no_such_device));
-    if (findBook(path) < 0)
+    const int index = findBook(path);
+    if (index < 0)
         return std::unexpected(std::make_error_code(std::errc::no_such_file_or_directory));
 
     const std::string ownedPath{path};
@@ -102,7 +103,7 @@ std::expected<void, std::error_code> StorageManager::removeBook(std::string_view
     Board::Storage::filesystem().remove(StoragePaths::indexedIndexPathFor(path).c_str());
     Board::Storage::filesystem().remove(StoragePaths::indexedDataPathFor(path).c_str());
     Board::Storage::filesystem().remove(StoragePaths::bookStatePathFor(path).c_str());
-    refreshBookPaths(false);
+    library_.erase(library_.begin() + index);
     return {};
 }
 


### PR DESCRIPTION
Deleting a book rescanned the entire card and discarded cached metadata for every remaining book. Remove the successfully deleted entry from StorageManager's existing listing instead. Failed deletions leave the cache intact, and the existing library-screen invalidation still updates the display.

Includes v0.1.1 release notes.

Validation: compiled StorageManager.cpp for waveshare_esp32s3_touch_lcd_349_rev1 with PlatformIO; git diff --check passed. Hardware deletion has not been tested.
