### PR TITLE
fix(companion): preserve USB frames and refresh live appearance

### DIFF
--- a/companion/apps/web/src/wasmJsMain/kotlin/com/rsvpnano/web/connection/WebSerialNanoApi.kt
+++ b/companion/apps/web/src/wasmJsMain/kotlin/com/rsvpnano/web/connection/WebSerialNanoApi.kt
@@ -320,8 +320,12 @@ internal class WebSerialNanoApi(
         try {
             while (scope.isActive && opened) {
                 decoder.feed(bridgeRead()).forEach { frame ->
-                    if (frame.type == SerialFrameType.Ping) sendFrame(SerialFrame(SerialFrameType.Pong), session)
-                    else session.send(frame)
+                    when (frame.type) {
+                        SerialFrameType.Ping -> sendFrame(SerialFrame(SerialFrameType.Pong), session)
+                        SerialFrameType.Pong -> Unit
+                        SerialFrameType.Close -> throw NanoClientError("The Nano ended the USB session.")
+                        else -> session.send(frame)
+                    }
                 }
             }
         } catch (cancelled: CancellationException) {

--- a/companion/apps/web/src/wasmJsMain/kotlin/com/rsvpnano/web/connection/WebSerialNanoApi.kt
+++ b/companion/apps/web/src/wasmJsMain/kotlin/com/rsvpnano/web/connection/WebSerialNanoApi.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -104,7 +103,6 @@ internal class WebSerialNanoApi(
     private val writeMutex = Mutex()
     private var frames = Channel<SerialFrame>(Channel.UNLIMITED)
     private var readerJob: Job? = null
-    private var heartbeatJob: Job? = null
     private var nextRequestId = 1u
     private var opened = false
     private var onDisconnect: (String) -> Unit = {}
@@ -123,31 +121,22 @@ internal class WebSerialNanoApi(
                 while (true) {
                     text = (text + bridgeRead().decodeToString()).takeLast(4096)
                     when {
-                        "RSVPNANO/COMPANION/1 READY" in text -> return@withTimeout text
+                        "RSVPNANO/COMPANION/1 READY" in text && '\n' in text.substringAfter("RSVPNANO/COMPANION/1 READY") -> return@withTimeout text
                         "BUSY MSC" in text -> throw NanoClientError("Exit USB Sync on the Nano before connecting the web companion.")
                         "UNSUPPORTED" in text -> throw NanoClientError("This firmware does not support USB companion protocol 1.")
                     }
                 }
                 @Suppress("UNREACHABLE_CODE") text
             }
-            check("READY" in greeting)
+            if ("RSVPNANO/COMPANION/1 READY persistent" !in greeting) {
+                throw NanoClientError("Update the Nano firmware to use persistent USB connections.")
+            }
             opened = true
             this.onDisconnect = onDisconnect
             frames = Channel(Channel.UNLIMITED)
             val session = frames
             readerJob = scope.launch { readFrames(session) }
-            heartbeatJob = scope.launch {
-                try {
-                    while (isActive) {
-                        delay(5_000)
-                        sendFrame(SerialFrame(SerialFrameType.Ping), session)
-                    }
-                } catch (cancelled: CancellationException) {
-                    throw cancelled
-                } catch (error: Throwable) {
-                    failSession(error, session)
-                }
-            }
+
             true
         } catch (error: Throwable) {
             withContext(NonCancellable) { bridgeCloseIgnoringErrors() }
@@ -347,7 +336,6 @@ internal class WebSerialNanoApi(
     private suspend fun closeSession(error: Throwable? = null) {
         if (opened && error == null) runCatching { sendFrame(SerialFrame(SerialFrameType.Close)) }
         opened = false
-        heartbeatJob?.cancel()
         readerJob?.cancel()
         frames.close(error)
         bridgeCloseIgnoringErrors()
@@ -419,10 +407,10 @@ private suspend fun bridgeCloseIgnoringErrors() = suspendCancellableCoroutine { 
     serialClose { if (continuation.isActive) continuation.resume(Unit) }
 }
 
-@JsFun("""(ok, fail) => { (async () => { try { const key = 'rsvpnano.web.usbDevice'; let saved = null; try { saved = JSON.parse(localStorage.getItem(key) || 'null'); } catch (_) { localStorage.removeItem(key); } const authorized = await navigator.serial.getPorts(); const matches = saved ? authorized.filter(port => { const info = port.getInfo(); return info.usbVendorId === saved.usbVendorId && info.usbProductId === saved.usbProductId; }) : []; const port = matches.length === 1 ? matches[0] : authorized.length === 1 ? authorized[0] : await navigator.serial.requestPort(); await port.open({ baudRate: 115200 }); const info = port.getInfo(); if (info.usbVendorId || info.usbProductId) localStorage.setItem(key, JSON.stringify({ usbVendorId: info.usbVendorId || 0, usbProductId: info.usbProductId || 0 })); globalThis.rsvpNanoSerial = { port, reader: port.readable.getReader(), writer: port.writable.getWriter() }; ok('ok'); } catch (error) { fail(error?.message || String(error)); } })(); }""")
+@JsFun("""(ok, fail) => { (async () => { try { const key = 'rsvpnano.web.usbDevice'; let saved = null; try { saved = JSON.parse(localStorage.getItem(key) || 'null'); } catch (_) { localStorage.removeItem(key); } const authorized = await navigator.serial.getPorts(); const matches = saved ? authorized.filter(port => { const info = port.getInfo(); return info.usbVendorId === saved.usbVendorId && info.usbProductId === saved.usbProductId; }) : []; const port = matches.length === 1 ? matches[0] : authorized.length === 1 ? authorized[0] : await navigator.serial.requestPort(); await port.open({ baudRate: 115200 }); await port.setSignals({ dataTerminalReady: true, requestToSend: true }).catch(async error => { await port.close(); throw error; }); const info = port.getInfo(); if (info.usbVendorId || info.usbProductId) localStorage.setItem(key, JSON.stringify({ usbVendorId: info.usbVendorId || 0, usbProductId: info.usbProductId || 0 })); globalThis.rsvpNanoSerial = { port, reader: port.readable.getReader(), writer: port.writable.getWriter() }; ok('ok'); } catch (error) { fail(error?.message || String(error)); } })(); }""")
 private external fun serialOpen(ok: (String) -> Unit, fail: (String) -> Unit)
 
-@JsFun("""(ok, fail) => { (async () => { try { const key = 'rsvpnano.web.usbDevice'; let saved = null; try { saved = JSON.parse(localStorage.getItem(key) || 'null'); } catch (_) { localStorage.removeItem(key); } const authorized = await navigator.serial.getPorts(); const matches = saved ? authorized.filter(port => { const info = port.getInfo(); return info.usbVendorId === saved.usbVendorId && info.usbProductId === saved.usbProductId; }) : authorized; if (matches.length !== 1) { ok(false); return; } const port = matches[0]; await port.open({ baudRate: 115200 }); const info = port.getInfo(); if (info.usbVendorId || info.usbProductId) localStorage.setItem(key, JSON.stringify({ usbVendorId: info.usbVendorId || 0, usbProductId: info.usbProductId || 0 })); globalThis.rsvpNanoSerial = { port, reader: port.readable.getReader(), writer: port.writable.getWriter() }; ok(true); } catch (error) { fail(error?.message || String(error)); } })(); }""")
+@JsFun("""(ok, fail) => { (async () => { try { const key = 'rsvpnano.web.usbDevice'; let saved = null; try { saved = JSON.parse(localStorage.getItem(key) || 'null'); } catch (_) { localStorage.removeItem(key); } const authorized = await navigator.serial.getPorts(); const matches = saved ? authorized.filter(port => { const info = port.getInfo(); return info.usbVendorId === saved.usbVendorId && info.usbProductId === saved.usbProductId; }) : authorized; if (matches.length !== 1) { ok(false); return; } const port = matches[0]; await port.open({ baudRate: 115200 }); await port.setSignals({ dataTerminalReady: true, requestToSend: true }).catch(async error => { await port.close(); throw error; }); const info = port.getInfo(); if (info.usbVendorId || info.usbProductId) localStorage.setItem(key, JSON.stringify({ usbVendorId: info.usbVendorId || 0, usbProductId: info.usbProductId || 0 })); globalThis.rsvpNanoSerial = { port, reader: port.readable.getReader(), writer: port.writable.getWriter() }; ok(true); } catch (error) { fail(error?.message || String(error)); } })(); }""")
 private external fun serialOpenAuthorized(ok: (Boolean) -> Unit, fail: (String) -> Unit)
 
 @JsFun("""(ok, fail) => { const serial = globalThis.rsvpNanoSerial; if (!serial) { fail('No USB port is open.'); return; } serial.reader.read().then(({ value, done }) => { if (done || !value) { ok(''); return; } let text = ''; for (let i = 0; i < value.length; i++) text += String.fromCharCode(value[i]); ok(btoa(text)); }).catch(error => fail(error?.message || String(error))); }""")

--- a/companion/apps/web/src/wasmJsTest/kotlin/com/rsvpnano/web/connection/WebSerialNanoApiTest.kt
+++ b/companion/apps/web/src/wasmJsTest/kotlin/com/rsvpnano/web/connection/WebSerialNanoApiTest.kt
@@ -14,6 +14,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.test.assertFailsWith
 import com.rsvpnano.api.NanoClientError
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -24,6 +25,28 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 class WebSerialNanoApiTest {
+    @Test
+    fun deviceCloseReleasesIdleSessionAndAllowsReconnect() = runTest {
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            val greeting = Base64.encode("RSVPNANO/COMPANION/1 READY\n".encodeToByteArray())
+            installFakeSerial(greeting)
+            val api = WebSerialNanoApi()
+            val disconnected = CompletableDeferred<Unit>()
+            var disconnects = 0
+            api.open(onDisconnect = { disconnects++; disconnected.complete(Unit) })
+            queueFakeSerialRead(Base64.encode(SerialFrameCodec.encode(SerialFrame(SerialFrameType.Close))))
+            withTimeout(1_000) { disconnected.await() }
+            assertEquals(1, fakeSerialCloseCount())
+            assertEquals(1, disconnects)
+
+            queueFakeSerialRead(greeting)
+            assertTrue(api.open())
+            api.release()
+            assertEquals(2, fakeSerialCloseCount())
+            assertEquals(1, disconnects)
+        }
+    }
+
     @Test
     fun uploadDisconnectStopsHeartbeatReleasesPortAndCanReconnect() = runTest {
         withContext(Dispatchers.Default.limitedParallelism(1)) {

--- a/companion/apps/web/src/wasmJsTest/kotlin/com/rsvpnano/web/connection/WebSerialNanoApiTest.kt
+++ b/companion/apps/web/src/wasmJsTest/kotlin/com/rsvpnano/web/connection/WebSerialNanoApiTest.kt
@@ -26,9 +26,37 @@ import kotlin.coroutines.resumeWithException
 
 class WebSerialNanoApiTest {
     @Test
+    fun idleSessionStaysOpenWithoutProbes() = runTest {
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            // The capability may arrive in a separate USB read from READY.
+            installFakeSerial(listOf("RSVPNANO/COMPANION/1 READY", " persistent\n")
+                .joinToString("|") { Base64.encode(it.encodeToByteArray()) })
+            val api = WebSerialNanoApi(backgroundScope)
+            assertTrue(api.open())
+            testScheduler.runCurrent()
+            testScheduler.advanceTimeBy(600_000)
+            testScheduler.runCurrent()
+            assertTrue(fakeSerialFrames().isEmpty(), "Idle connections must not send probes")
+            assertEquals(0, fakeSerialCloseCount())
+            api.release()
+            assertEquals(1, fakeSerialCloseCount())
+        }
+    }
+
+    @Test
+    fun legacyFirmwareRequiresUpdateInsteadOfSilentlyTimingOut() = runTest {
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            installFakeSerial(Base64.encode("RSVPNANO/COMPANION/1 READY\n".encodeToByteArray()))
+            val error = assertFailsWith<NanoClientError> { WebSerialNanoApi().open() }
+            assertTrue(error.message.orEmpty().contains("Update the Nano firmware"))
+            assertEquals(1, fakeSerialCloseCount())
+        }
+    }
+
+    @Test
     fun deviceCloseReleasesIdleSessionAndAllowsReconnect() = runTest {
         withContext(Dispatchers.Default.limitedParallelism(1)) {
-            val greeting = Base64.encode("RSVPNANO/COMPANION/1 READY\n".encodeToByteArray())
+            val greeting = Base64.encode("RSVPNANO/COMPANION/1 READY persistent\n".encodeToByteArray())
             installFakeSerial(greeting)
             val api = WebSerialNanoApi()
             val disconnected = CompletableDeferred<Unit>()
@@ -48,9 +76,9 @@ class WebSerialNanoApiTest {
     }
 
     @Test
-    fun uploadDisconnectStopsHeartbeatReleasesPortAndCanReconnect() = runTest {
+    fun uploadDisconnectReleasesPortAndCanReconnect() = runTest {
         withContext(Dispatchers.Default.limitedParallelism(1)) {
-            val greeting = "RSVPNANO/COMPANION/1 READY\n".encodeToByteArray()
+            val greeting = "RSVPNANO/COMPANION/1 READY persistent\n".encodeToByteArray()
             val ack = SerialFrameCodec.encode(SerialFrame(SerialFrameType.Acknowledgement, 1u))
             installFakeSerial(listOf(greeting, ack).joinToString("|") { Base64.encode(it) })
             val api = WebSerialNanoApi(backgroundScope)
@@ -66,9 +94,9 @@ class WebSerialNanoApiTest {
             val sent = fakeSerialFrames()
             assertEquals(371, sent.single { it.type == SerialFrameType.Data }.payload.size)
             assertEquals(SerialFrameType.End, sent.last().type)
-            testScheduler.advanceTimeBy(5_100)
+            testScheduler.advanceTimeBy(600_000)
             testScheduler.runCurrent()
-            assertEquals(sent.size, fakeSerialFrames().size, "Disconnected sessions must stop their heartbeat")
+            assertEquals(sent.size, fakeSerialFrames().size, "Disconnected sessions must not send more data")
 
             queueFakeSerialRead(Base64.encode(greeting))
             assertTrue(api.open(onDisconnect = { disconnects++ }))
@@ -88,7 +116,7 @@ class WebSerialNanoApiTest {
     @Test
     fun writeFailureAndRequestCancellationReleaseTheirSession() = runTest {
         withContext(Dispatchers.Default.limitedParallelism(1)) {
-            val greeting = Base64.encode("RSVPNANO/COMPANION/1 READY\n".encodeToByteArray())
+            val greeting = Base64.encode("RSVPNANO/COMPANION/1 READY persistent\n".encodeToByteArray())
             installFakeSerial(greeting)
             val api = WebSerialNanoApi()
             var disconnects = 0
@@ -120,7 +148,7 @@ class WebSerialNanoApiTest {
                 SerialFrameCodec.encode(SerialFrame(SerialFrameType.Response, 1u, payload = metadata)) +
                 SerialFrameCodec.encode(SerialFrame(SerialFrameType.Data, 1u, payload = errorBody)) +
                 SerialFrameCodec.encode(SerialFrame(SerialFrameType.End, 1u))
-            installFakeSerial(Base64.encode("RSVPNANO/COMPANION/1 READY\n".encodeToByteArray()) + "|" + Base64.encode(response))
+            installFakeSerial(Base64.encode("RSVPNANO/COMPANION/1 READY persistent\n".encodeToByteArray()) + "|" + Base64.encode(response))
             val api = WebSerialNanoApi()
             var disconnects = 0
             api.open(onDisconnect = { disconnects++ })
@@ -142,7 +170,7 @@ class WebSerialNanoApiTest {
     @Test
     fun cancellingStalledWriteAbortsStreamBeforeClosingPort() = runTest {
         withContext(Dispatchers.Default.limitedParallelism(1)) {
-            installFakeSerial(Base64.encode("RSVPNANO/COMPANION/1 READY\n".encodeToByteArray()))
+            installFakeSerial(Base64.encode("RSVPNANO/COMPANION/1 READY persistent\n".encodeToByteArray()))
             val api = WebSerialNanoApi()
             api.open()
             stallFakeSerialWrites()
@@ -185,7 +213,7 @@ class WebSerialNanoApiTest {
                 SerialFrameCodec.encode(SerialFrame(SerialFrameType.Response, 2u, payload = repairMetadata.encodeToByteArray())) +
                     SerialFrameCodec.encode(SerialFrame(SerialFrameType.Data, 2u, payload = repairBody)) +
                     SerialFrameCodec.encode(SerialFrame(SerialFrameType.End, 2u))
-            val reads = listOf("RSVPNANO/COMPANION/1 READY\n".encodeToByteArray(), response, repairResponse)
+            val reads = listOf("RSVPNANO/COMPANION/1 READY persistent\n".encodeToByteArray(), response, repairResponse)
                 .joinToString("|") { Base64.encode(it) }
             installFakeSerial(reads)
             val api = WebSerialNanoApi()
@@ -223,7 +251,7 @@ private external fun installBootloaderResetSerial(openFails: Boolean)
 @JsFun("""() => { const state = globalThis.rsvpNanoBootloaderReset; return state.baudRate + '|' + state.closes + '|' + state.signals; }""")
 private external fun bootloaderResetState(): String
 
-@JsFun("""(encodedReads) => { const decode = encoded => { const text = atob(encoded); const bytes = new Uint8Array(text.length); for (let i = 0; i < text.length; i++) bytes[i] = text.charCodeAt(i); return bytes; }; const reads = encodedReads.split('|').map(decode); const state = { opened: false, opens: 0, closes: 0, reads, writes: [], pendingRead: null }; const port = { getInfo: () => ({ usbVendorId: 0x303a, usbProductId: 0x1001 }), open: async () => { if (state.opened) throw new Error('Port is already open'); state.opened = true; state.opens++; }, close: async () => { state.opened = false; state.closes++; }, readable: { getReader: () => ({ read: async () => state.reads.length ? { value: state.reads.shift(), done: false } : new Promise(resolve => { state.pendingRead = resolve; }), cancel: async () => { state.pendingRead?.({ done: true }); state.pendingRead = null; }, releaseLock: () => {} }) }, writable: { getWriter: () => ({ write: async data => { state.writes.push(new Uint8Array(data)); }, close: async () => {}, releaseLock: () => {} }) } }; state.port = port; globalThis.rsvpNanoFakeSerial = state; Object.defineProperty(navigator, 'serial', { configurable: true, value: { getPorts: async () => [port], requestPort: async () => port } }); localStorage.removeItem('rsvpnano.web.usbDevice'); }""")
+@JsFun("""(encodedReads) => { const decode = encoded => { const text = atob(encoded); const bytes = new Uint8Array(text.length); for (let i = 0; i < text.length; i++) bytes[i] = text.charCodeAt(i); return bytes; }; const reads = encodedReads.split('|').map(decode); const state = { opened: false, opens: 0, closes: 0, reads, writes: [], pendingRead: null }; const port = { setSignals: async signals => { state.signals = signals; }, getInfo: () => ({ usbVendorId: 0x303a, usbProductId: 0x1001 }), open: async () => { if (state.opened) throw new Error('Port is already open'); state.opened = true; state.opens++; }, close: async () => { state.opened = false; state.closes++; }, readable: { getReader: () => ({ read: async () => state.reads.length ? { value: state.reads.shift(), done: false } : new Promise(resolve => { state.pendingRead = resolve; }), cancel: async () => { state.pendingRead?.({ done: true }); state.pendingRead = null; }, releaseLock: () => {} }) }, writable: { getWriter: () => ({ write: async data => { state.writes.push(new Uint8Array(data)); }, close: async () => {}, releaseLock: () => {} }) } }; state.port = port; globalThis.rsvpNanoFakeSerial = state; Object.defineProperty(navigator, 'serial', { configurable: true, value: { getPorts: async () => [port], requestPort: async () => port } }); localStorage.removeItem('rsvpnano.web.usbDevice'); }""")
 private external fun installFakeSerial(encodedReads: String)
 
 @JsFun("""() => { const state = globalThis.rsvpNanoFakeSerial; const write = globalThis.rsvpNanoSerial.writer.write; globalThis.rsvpNanoSerial.writer.write = async data => { await write(data); if (data[5] === 3) { state.pendingRead?.({ done: true }); state.pendingRead = null; } }; }""")

--- a/docs/companion-api.md
+++ b/docs/companion-api.md
@@ -79,3 +79,9 @@ The default run performs three complete read passes and reports request latency.
 Use `--no-upload --base-url http://DEVICE_IP` to rerun against API-test firmware already installed. The hardware test is skipped during ordinary Gradle checks unless `RSVPNANO_DEVICE_URL` is set.
 
 The implementation is organized by domain under `src/companion`; the main app contains no benchmark or API-test branches.
+
+### USB connection lifetime
+
+USB companion sessions remain open until the host closes the port, the cable disconnects, or a transport error ends the session. There is no idle timeout and the browser sends no periodic keepalive probes. The browser asserts DTR and RTS when opening the serial port; firmware uses the native CDC connection state to release abandoned sessions.
+
+Firmware advertises this behavior with `RSVPNANO/COMPANION/1 READY persistent\n`. The browser requires this capability and requests a firmware update for older devices with timed sessions. Existing clients can still send Ping frames and receive Pong responses.

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -142,6 +142,7 @@ void App::update(uint32_t nowMs) {
     }
 
     if (companionApi_.active() || serialCompanion_.active()) {
+        companionApi_.renderStatus(serialCompanion_.active());
         settingsStore_.update(nowMs);
         Board::Power::updateBattery(battery_, nowMs);
         return;
@@ -170,7 +171,7 @@ void App::update(uint32_t nowMs) {
 
 void App::renderScreen(uint32_t nowMs) {
     if (serialCompanion_.active()) {
-        screens::status(immediateUi_, "USB companion", "Connected", "Keep the browser open");
+        companionApi_.renderStatus(true);
         return;
     }
     const screens::Screen renderedScreen = screen_;

--- a/src/companion/http/CompanionApi.cpp
+++ b/src/companion/http/CompanionApi.cpp
@@ -105,6 +105,14 @@ bool CompanionApi::active() const {
     return active_.load();
 }
 
+void CompanionApi::renderStatus(bool usbConnected) {
+    const std::scoped_lock lock{operationsMutex_, networkStateMutex_};
+    if (usbConnected)
+        screens::status(ui_, "USB companion", "Connected", "Keep the browser open");
+    else
+        screens::status(ui_, ui_.text(UiText::Sync), statusLine1(), statusLine2());
+}
+
 std::string_view CompanionApi::statusLine1() const {
     if (stationConnected_.load())
         return settingsStore_.settings().network.ssid;
@@ -193,7 +201,7 @@ void CompanionApi::queueNetworkState() {
 
 void CompanionApi::applyNetworkState(void* context) {
     auto& self = *static_cast<CompanionApi*>(context);
-    const std::lock_guard lock{self.networkStateMutex_};
+    const std::scoped_lock lock{self.operationsMutex_, self.networkStateMutex_};
     if (!self.active())
         return;
     const bool stationConnected = WiFi.status() == WL_CONNECTED;

--- a/src/companion/http/CompanionApi.h
+++ b/src/companion/http/CompanionApi.h
@@ -49,6 +49,7 @@ public:
     bool begin();
     void end();
     [[nodiscard]] bool active() const;
+    void renderStatus(bool usbConnected);
     [[nodiscard]] std::string_view statusLine1() const;
     [[nodiscard]] std::string_view statusLine2() const;
 

--- a/src/companion/serial/CompanionSerial.cpp
+++ b/src/companion/serial/CompanionSerial.cpp
@@ -3,6 +3,9 @@
 #include <glaze/json.hpp>
 
 #include <WiFi.h>
+#if !ARDUINO_USB_MODE
+#include <tusb.h>
+#endif
 
 #include <algorithm>
 #include <array>
@@ -74,7 +77,12 @@ void CompanionSerial::update(uint32_t nowMs) {
         return;
     }
 
+#if ARDUINO_USB_MODE
     if (!Serial) {
+#else
+    // Arduino's connection flag also tracks the bootloader reset sequence; use the actual CDC DTR state.
+    if (!tud_cdc_connected()) {
+#endif
         close();
         return;
     }

--- a/src/companion/serial/CompanionSerial.cpp
+++ b/src/companion/serial/CompanionSerial.cpp
@@ -76,8 +76,10 @@ void CompanionSerial::update(uint32_t nowMs) {
     }
 
     readFrames(nowMs);
-    if (nowMs - lastTrafficMs_ >= kSessionTimeoutMs)
+    if (nowMs - lastTrafficMs_ >= kSessionTimeoutMs) {
+        sendFrame({.type = companion::serial::FrameType::Close});
         close();
+    }
 }
 
 void CompanionSerial::close() {
@@ -113,12 +115,16 @@ void CompanionSerial::readHandshake(uint32_t nowMs) {
             return;
         }
 
+        // Keep a complete upload chunk plus metadata queued while the app is busy with SD/NVS work.
+        if (Serial.setRxBufferSize(2 * companion::serial::kChunkBytes) == 0)
+            return;
         Serial.setDebugOutput(false);
         Serial.print("RSVPNANO/COMPANION/1 READY\n");
         Serial.flush();
         decoder_.clear();
         resetRequest();
         active_ = true;
+        writeFailed_ = false;
         lastTrafficMs_ = nowMs;
         return;
     }
@@ -255,8 +261,13 @@ void CompanionSerial::readFrames(uint32_t nowMs) {
         lastTrafficMs_ = nowMs;
         decoder_.append(std::span{bytes}.first(count));
     }
-    for (auto& frame: decoder_.takeFrames())
+    for (auto& frame: decoder_.takeFrames()) {
         handleFrame(std::move(frame), nowMs);
+        if (writeFailed_)
+            close();
+        if (!active_)
+            break;
+    }
 }
 
 void CompanionSerial::handleFrame(companion::serial::Frame frame, uint32_t nowMs) {
@@ -602,9 +613,18 @@ void CompanionSerial::sendProtocolError(uint32_t requestId, std::string message)
 }
 
 void CompanionSerial::sendFrame(companion::serial::Frame frame) {
+    if (writeFailed_)
+        return;
     const auto bytes = companion::serial::encode(frame);
-    if (!bytes.empty())
-        Serial.write(bytes.data(), bytes.size());
+    for (size_t offset = 0; offset < bytes.size();) {
+        const size_t written = Serial.write(bytes.data() + offset, bytes.size() - offset);
+        if (written == 0) {
+            // Finish unwinding the active request before releasing its buffers.
+            writeFailed_ = true;
+            return;
+        }
+        offset += written;
+    }
 }
 
 void CompanionSerial::resetRequest() {

--- a/src/companion/serial/CompanionSerial.cpp
+++ b/src/companion/serial/CompanionSerial.cpp
@@ -20,7 +20,6 @@
 namespace {
 
     constexpr std::string_view kHandshake = "RSVPNANO/COMPANION/1\n";
-    constexpr uint32_t kSessionTimeoutMs = 15'000;
     constexpr size_t kMaximumJsonRequestBytes = 8 * 1024;
     constexpr uint64_t kMaximumRequestBytes = 256ULL * 1024ULL * 1024ULL;
     constexpr std::string_view kSpoolPath = "/.companion-usb-request.tmp";
@@ -75,11 +74,11 @@ void CompanionSerial::update(uint32_t nowMs) {
         return;
     }
 
-    readFrames(nowMs);
-    if (nowMs - lastTrafficMs_ >= kSessionTimeoutMs) {
-        sendFrame({.type = companion::serial::FrameType::Close});
+    if (!Serial) {
         close();
+        return;
     }
+    readFrames();
 }
 
 void CompanionSerial::close() {
@@ -119,13 +118,12 @@ void CompanionSerial::readHandshake(uint32_t nowMs) {
         if (Serial.setRxBufferSize(2 * companion::serial::kChunkBytes) == 0)
             return;
         Serial.setDebugOutput(false);
-        Serial.print("RSVPNANO/COMPANION/1 READY\n");
+        Serial.print("RSVPNANO/COMPANION/1 READY persistent\n");
         Serial.flush();
         decoder_.clear();
         resetRequest();
         active_ = true;
         writeFailed_ = false;
-        lastTrafficMs_ = nowMs;
         return;
     }
 }
@@ -252,17 +250,16 @@ void CompanionSerial::sendImprovResponse(improv::Command command, const std::vec
     sendImprov(improv::TYPE_RPC_RESPONSE, data);
 }
 
-void CompanionSerial::readFrames(uint32_t nowMs) {
+void CompanionSerial::readFrames() {
     std::array<uint8_t, 512> bytes{};
     while (Serial.available() > 0) {
         const size_t count = Serial.readBytes(bytes.data(), std::min<size_t>(Serial.available(), bytes.size()));
         if (count == 0)
             break;
-        lastTrafficMs_ = nowMs;
         decoder_.append(std::span{bytes}.first(count));
     }
     for (auto& frame: decoder_.takeFrames()) {
-        handleFrame(std::move(frame), nowMs);
+        handleFrame(std::move(frame));
         if (writeFailed_)
             close();
         if (!active_)
@@ -270,9 +267,8 @@ void CompanionSerial::readFrames(uint32_t nowMs) {
     }
 }
 
-void CompanionSerial::handleFrame(companion::serial::Frame frame, uint32_t nowMs) {
+void CompanionSerial::handleFrame(companion::serial::Frame frame) {
     using companion::serial::FrameType;
-    lastTrafficMs_ = nowMs;
     switch (frame.type) {
     case FrameType::Ping:
         sendFrame({.type = FrameType::Pong});

--- a/src/companion/serial/CompanionSerial.h
+++ b/src/companion/serial/CompanionSerial.h
@@ -55,8 +55,8 @@ private:
     void sendImprovState(improv::State state);
     void sendImprovError(improv::Error error);
     void sendImprovResponse(improv::Command command, const std::vector<std::string>& values);
-    void readFrames(uint32_t nowMs);
-    void handleFrame(companion::serial::Frame frame, uint32_t nowMs);
+    void readFrames();
+    void handleFrame(companion::serial::Frame frame);
     void handleRequestEnd(const companion::serial::Frame& frame);
     void dispatchRequest(companion::BufferedRequest& buffered);
     void sendResponse(uint32_t requestId, int status, std::string body);
@@ -85,7 +85,6 @@ private:
     uint32_t responseRequestId_ = 0;
     uint32_t responseSequence_ = 0;
     size_t responseOffset_ = 0;
-    uint32_t lastTrafficMs_ = 0;
     uint32_t improvLastByteMs_ = 0;
     uint32_t provisioningDeadlineMs_ = 0;
     improv::State improvState_ = improv::STATE_AUTHORIZED;

--- a/src/companion/serial/CompanionSerial.h
+++ b/src/companion/serial/CompanionSerial.h
@@ -90,5 +90,6 @@ private:
     uint32_t provisioningDeadlineMs_ = 0;
     improv::State improvState_ = improv::STATE_AUTHORIZED;
     bool active_ = false;
+    bool writeFailed_ = false;
     bool requestSpooled_ = false;
 };

--- a/src/ui/Ui.cpp
+++ b/src/ui/Ui.cpp
@@ -113,10 +113,9 @@ namespace ui {
     }
 
     void Context::setTheme(const ui::themes::Theme& theme) {
-        if (theme_ != &theme) {
-            theme_ = &theme;
-            invalidate();
-        }
+        // Installing/removing themes can move another theme into the same catalog address.
+        theme_ = &theme;
+        invalidate();
     }
 
     void Context::setLanguageCatalog(fs::FS* filesystem, const locales::Catalog* catalog,


### PR DESCRIPTION
USB companion sessions now remain open without idle timeouts or periodic browser probes. The browser asserts DTR/RTS when opening the port, and firmware uses the native USB connection state to release a closed or unplugged port. On TinyUSB targets this is the actual CDC/DTR state, because Arduino's higher-level connection flag also tracks bootloader reset sequences and can falsely report a normal reopened port as disconnected.

Firmware advertises persistent sessions in its greeting. The browser requests an update from older firmware rather than silently losing the connection when its old timeout expires. Existing clients can still exchange Ping/Pong frames.

The change also sizes Arduino's receive queue to 8 KiB for 4096-byte upload chunks, preserves partial USB writes, and keeps the companion status screen in the cached render loop under endpoint/network locks. Theme changes invalidate the render cache even when catalog mutations reuse an address, allowing newly installed themes to apply while connected.

Validation:
- Built and flashed the isolated fix sources to the connected ESP32-S3 LCD 3.49; esptool verified the written image hash.
- Device remained usable after 65 seconds with no traffic in either direction.
- Three consecutive native port-close/reopen cycles passed.
- Closed the port during an unfinished spooled upload without sending Close; reconnect completed in 51 ms, device requests succeeded, and a subsequent upload returned the expected application error.
- Explicit protocol Close also allowed immediate reconnect. No asset was installed by these lifecycle tests.
- Browser regression tests cover ten minutes of virtual idle time with no probes, fragmented capability greetings, legacy firmware cleanup, peer closure, and reconnect behavior.
- Earlier device checks for the same upload/theme fixes passed full-size chunk transfers, five theme reinstall cycles with the original catalog restored, and repeated endpoint requests including a 9962-byte library response.

Physical screen pixels were not captured automatically. Other pending workspace changes are excluded from this PR and the isolated firmware source snapshot.
