### PR TITLE
perf(display): batch AMOLED paints in 32-row bands

### DIFF
--- a/docs/hardware/esp32-s3-touch-amoled-2.06-bringup-notes.md
+++ b/docs/hardware/esp32-s3-touch-amoled-2.06-bringup-notes.md
@@ -14,7 +14,7 @@
 
 - MCU: `ESP32-S3R8`
 - Display: `CO5300`, `410x502`, QSPI
-- App/UI geometry: `502x410` landscape, using rotated two-row updates at native panel rotation zero.
+- App/UI geometry: `502x410` landscape, using rotated 32-row updates at native panel rotation zero.
 - Touch: `FT3168` routed through the FT6336-compatible driver at I2C `0x38`
 - PMU: `AXP2101`
 - IMU: `QMI8658`

--- a/docs/hardware/esp32-s3-touch-amoled-2.16-bringup-notes.md
+++ b/docs/hardware/esp32-s3-touch-amoled-2.16-bringup-notes.md
@@ -38,7 +38,7 @@ The board implementation binds its private wiring to the stable `Board::*` API:
 ## Display Notes
 
 - The controller requires even starts and even dimensions. The shared UI composes aligned
-  two-row updates; see the [hardware audit](hardware-audit.md).
+  32-row updates; see the [hardware audit](hardware-audit.md).
 - The square panel stays at native rotation zero while the UI and touch rotate together.
 - The board uses safe reader chrome margins for the rounded screen mask.
 

--- a/docs/hardware/esp32-s3-touch-amoled-2.41-bringup-notes.md
+++ b/docs/hardware/esp32-s3-touch-amoled-2.41-bringup-notes.md
@@ -60,7 +60,7 @@ The shared app does not include platform or chip-driver headers directly.
 
 ### Rotation
 
-Keep panel addressing at native rotation zero. The shared UI composes rotated two-row strips
+Keep panel addressing at native rotation zero. The shared UI composes rotated 32-row strips
 for the landscape layout, and touch uses the matching logical transform.
 
 ### Color Format

--- a/docs/hardware/hardware-audit.md
+++ b/docs/hardware/hardware-audit.md
@@ -32,7 +32,7 @@ framework disables hardware read-modify-write atomics, even though word loads/st
 ## Aligned rendering and orientation
 
 The existing UI primitives compose complete opaque regions into one reusable native Arduino_GFX
-two-row canvas before sending aligned rectangles. There is no full-screen framebuffer, panel
+32-row canvas before sending aligned rectangles. There is no full-screen framebuffer, panel
 readback, retained draw-command list, or second UI model. The existing LCD 3.49 AXS15231B
 canvas/row-prefix implementation and C6 direct drawing path do not compile this strip buffer.
 
@@ -93,12 +93,12 @@ Removing the redundant packed-pixel color table saves 1,024 bytes per font rende
 geometry adds 8 bytes per word and 4 per bidi character, plus line bounds; it is not a claim that
 total working memory always decreases. No additional font objects or pixel buffers are created.
 
-| Board | Default UI size | Two-row RGB565 allocation |
+| Board | Default UI size | 32-row RGB565 allocation |
 |---|---|---|
-| AMOLED 1.8 V1/V2 | 448 x 368 | 1,472 bytes |
-| AMOLED 2.06 | 502 x 410 | 1,648 bytes |
-| AMOLED 2.16 | 480 x 480 | 1,920 bytes |
-| AMOLED 2.41 V1 | 600 x 450 | 1,808 bytes |
+| AMOLED 1.8 V1/V2 | 448 x 368 | 23,552 bytes |
+| AMOLED 2.06 | 502 x 410 | 26,368 bytes |
+| AMOLED 2.16 | 480 x 480 | 30,720 bytes |
+| AMOLED 2.41 V1 | 600 x 450 | 28,928 bytes |
 | C6 LCD 1.47 | 320 x 172 | None |
 
 The row pitch rounds up to four pixels for Arduino_Canvas's allocation alignment. Transfer payloads
@@ -106,6 +106,12 @@ are packed to the actual window width. AMOLED panels remain at native rotation z
 canvas rotates each strip and the existing touch transform follows the same orientation. The
 left-handed setting selects the opposite landscape orientation. Board configuration selects the
 path at compile time; the regular LCD 3.49 layout is unchanged.
+
+The 32-row setting replaces the two-row allocation in that same canvas. On the 1.8 a full-screen
+paint needs 14 callbacks/transfers instead of 224, with the same total pixel payload. The final
+band sends only the remaining even rows. This reduces repeated drawing and window setup without
+adding asynchronous buffer ownership or a second allocation. It is not a measured frame-rate claim.
+RSVP region bounds remain unchanged: centering metrics do not bound every shaped glyph or phantom.
 
 Arduino_GFX is pinned to the audited revision. Its u8g2 decoder used unsigned temporary coordinates,
 which dropped glyph fragments crossing the strip edge. `tools/pio_gfx.py` builds a generated copy
@@ -153,9 +159,10 @@ Build/host tests cannot replace these checks on each affected revision:
   light-sleep and existing firmware suites. The final rendering recheck includes exact transfer
   counts, clipped/odd regions, touch rotation, incremental highlights, keyboard invalidation,
   screensavers and moved/removed widget ownership.
-- The native Arduino_GFX regression passes 192 single-line and 192 newline pixel comparisons,
-  including prepared-text clipping. The original unsigned decoder fails 162 single-line cases;
-  omitting full logical text bounds fails 138. Run `python test/native_canvas/run.py --fetch-library`.
+- The native Arduino_GFX regression passes 1,536 cases at 2/16/32/64 rows across the four AMOLED
+  panel sizes and two smaller, padded/short-tail surfaces. Each case compares single-line and
+  newline output, with and without prepared-text clipping. Omitting full logical text bounds
+  fails 838 cases. Run `python test/native_canvas/run.py --fetch-library`.
 - `checkWeb` and the production installer bundle passed. Committed conflict markers and a duplicate
   import in the USB regression test were removed without discarding its book-deletion check.
 - The firmware-export script passed its syntax check.

--- a/docs/releases/v0.1.1.md
+++ b/docs/releases/v0.1.1.md
@@ -2,8 +2,12 @@
 
 - Update the Nano's cached library after deleting a book instead of rescanning
   the card after every deletion. Other books retain their cached metadata.
-- Render AMOLED menus and readers using aligned two-row transfers, without a
+- Render AMOLED menus and readers using aligned 32-row transfers, without a
   full-screen framebuffer. Fix clipped font fragments and partial-highlight redraws.
+- Reuse one partial canvas configured per board: 23 KiB on the AMOLED 1.8.
+  A full-screen paint now uses 14 transfers instead of 224 on that panel.
+  Short final bands and all four rotations retain pixel-level regression coverage;
+  physical rendering speed still needs tester confirmation.
 - Prepare text layout once per changed widget, skip off-screen page glyphs, and
   avoid duplicate clears and full-screen redraws when selecting carousel items.
   Remove the font renderer's redundant color table and reuse each card's touch slot.

--- a/src/platforms/waveshare_amoled_18/BoardConfig.h
+++ b/src/platforms/waveshare_amoled_18/BoardConfig.h
@@ -18,6 +18,7 @@ namespace Board::Config {
     constexpr int PANEL_NATIVE_WIDTH = WaveshareAmoled18::DisplayWiring::kPanelWidth;
     constexpr int PANEL_NATIVE_HEIGHT = WaveshareAmoled18::DisplayWiring::kPanelHeight;
     constexpr int DISPLAY_WRITE_ALIGNMENT = 2;
+    constexpr int DISPLAY_BUFFER_ROWS = 32;
     constexpr int DISPLAY_WIDTH = PANEL_NATIVE_HEIGHT;
     constexpr int DISPLAY_HEIGHT = PANEL_NATIVE_WIDTH;
     constexpr int READER_CHROME_MARGIN_X = 40;

--- a/src/platforms/waveshare_amoled_206/BoardConfig.h
+++ b/src/platforms/waveshare_amoled_206/BoardConfig.h
@@ -18,6 +18,7 @@ namespace Board::Config {
     constexpr int PANEL_NATIVE_WIDTH = WaveshareAmoled206::DisplayWiring::kPanelWidth;
     constexpr int PANEL_NATIVE_HEIGHT = WaveshareAmoled206::DisplayWiring::kPanelHeight;
     constexpr int DISPLAY_WRITE_ALIGNMENT = 2;
+    constexpr int DISPLAY_BUFFER_ROWS = 32;
     constexpr int DISPLAY_WIDTH = PANEL_NATIVE_HEIGHT;
     constexpr int DISPLAY_HEIGHT = PANEL_NATIVE_WIDTH;
     constexpr int READER_CHROME_MARGIN_X = 48;

--- a/src/platforms/waveshare_amoled_216/BoardConfig.h
+++ b/src/platforms/waveshare_amoled_216/BoardConfig.h
@@ -18,6 +18,7 @@ namespace Board::Config {
     constexpr int PANEL_NATIVE_WIDTH = WaveshareAmoled216::DisplayWiring::kPanelWidth;
     constexpr int PANEL_NATIVE_HEIGHT = WaveshareAmoled216::DisplayWiring::kPanelHeight;
     constexpr int DISPLAY_WRITE_ALIGNMENT = 2;
+    constexpr int DISPLAY_BUFFER_ROWS = 32;
     constexpr int DISPLAY_WIDTH = PANEL_NATIVE_HEIGHT;
     constexpr int DISPLAY_HEIGHT = PANEL_NATIVE_WIDTH;
     constexpr int READER_CHROME_MARGIN_X = 48;

--- a/src/platforms/waveshare_amoled_241/BoardConfig.h
+++ b/src/platforms/waveshare_amoled_241/BoardConfig.h
@@ -18,6 +18,7 @@ namespace Board::Config {
     constexpr int PANEL_NATIVE_WIDTH = WaveshareAmoled241::DisplayWiring::kPanelWidth;
     constexpr int PANEL_NATIVE_HEIGHT = WaveshareAmoled241::DisplayWiring::kPanelHeight;
     constexpr int DISPLAY_WRITE_ALIGNMENT = 2;
+    constexpr int DISPLAY_BUFFER_ROWS = 32;
     constexpr int DISPLAY_WIDTH = PANEL_NATIVE_HEIGHT;
     constexpr int DISPLAY_HEIGHT = PANEL_NATIVE_WIDTH;
     constexpr int READER_CHROME_MARGIN_X = 12;

--- a/src/platforms/waveshare_c6_touch_lcd_147/BoardConfig.h
+++ b/src/platforms/waveshare_c6_touch_lcd_147/BoardConfig.h
@@ -4,6 +4,7 @@
 
 namespace Board::Config {
     constexpr int DISPLAY_WRITE_ALIGNMENT = 1;
+    constexpr int DISPLAY_BUFFER_ROWS = 0;
 
     constexpr const char* BOARD_ID = "waveshare_esp32c6_touch_lcd_1_47";
     constexpr const char* BOARD_LABEL = "Waveshare ESP32-C6-Touch-LCD-1.47";

--- a/src/platforms/waveshare_lcd_349/BoardConfig.h
+++ b/src/platforms/waveshare_lcd_349/BoardConfig.h
@@ -4,6 +4,7 @@
 
 namespace Board::Config {
     constexpr int DISPLAY_WRITE_ALIGNMENT = 1;
+    constexpr int DISPLAY_BUFFER_ROWS = 0;
 
     constexpr const char* BOARD_ID = WaveshareLcd349::Revision::kBoardId;
     constexpr const char* BOARD_LABEL = WaveshareLcd349::Revision::kBoardLabel;

--- a/src/ui/Ui.cpp
+++ b/src/ui/Ui.cpp
@@ -101,7 +101,9 @@ namespace ui {
         if constexpr (displayWriteAlignment() > 1) {
             // aligned_alloc used by Arduino_Canvas requires a multiple-of-16 allocation size.
             constexpr int16_t pitch = (Board::Config::PANEL_NATIVE_WIDTH + 3) & ~3;
-            static Arduino_Canvas buffer(pitch, 2, nullptr);
+            constexpr int16_t rows = Board::Config::DISPLAY_BUFFER_ROWS;
+            static_assert(displayWriteAlignment() == 1 || (rows > 0 && rows % displayWriteAlignment() == 0));
+            static Arduino_Canvas buffer(pitch, rows, nullptr);
             if (gfx_.width() <= pitch && buffer.begin(GFX_SKIP_OUTPUT_BEGIN))
                 return &buffer;
         }

--- a/src/ui/Ui.h
+++ b/src/ui/Ui.h
@@ -189,6 +189,7 @@ namespace ui {
                 buffer->setRotation(rotation);
                 const int16_t panelW = gfx_.width(), panelH = gfx_.height();
                 const int16_t pitch = (rotation & 1U) ? buffer->height() : buffer->width();
+                const int16_t rows = (rotation & 1U) ? buffer->width() : buffer->height();
                 Rect window = rect;
                 switch (rotation) {
                 case 1:
@@ -207,7 +208,8 @@ namespace ui {
                 window = intersection(window, {0, 0, panelW, panelH});
                 if (window.w <= 0 || window.h <= 0)
                     return;
-                for (int16_t y = window.y; y < window.y + window.h; y += 2) {
+                for (int16_t y = window.y; y < window.y + window.h; y += rows) {
+                    const int16_t count = std::min<int16_t>(rows, window.y + window.h - y);
                     int16_t dx = -window.x, dy = -y;
                     switch (rotation) {
                     case 1:
@@ -216,10 +218,10 @@ namespace ui {
                         break;
                     case 2:
                         dx = pitch - panelW + window.x;
-                        dy = y - panelH + 2;
+                        dy = y - panelH + rows;
                         break;
                     case 3:
-                        dx = y - panelH + 2;
+                        dx = y - panelH + rows;
                         dy = -window.x;
                         break;
                     default:
@@ -229,13 +231,16 @@ namespace ui {
                     buffer->setTextBound(dx, dy, width(), height());
                     uint16_t* pixels = buffer->getFramebuffer();
                     const uint16_t background = color(themes::Background);
-                    std::fill_n(pixels, window.w, background);
-                    std::fill_n(pixels + pitch, window.w, background);
+                    for (int16_t row = 0; row < count; ++row)
+                        std::fill_n(pixels + row * pitch, window.w, background);
                     draw(*buffer,
                          Rect{static_cast<int16_t>(rect.x + dx), static_cast<int16_t>(rect.y + dy), rect.w, rect.h});
                     // Canvas rows retain their full pitch; the panel takes a tightly packed rectangle.
-                    std::memmove(pixels + window.w, pixels + pitch, static_cast<size_t>(window.w) * sizeof(*pixels));
-                    gfx_.draw16bitRGBBitmap(window.x, y, pixels, window.w, 2);
+                    if (window.w != pitch)
+                        for (int16_t row = 1; row < count; ++row)
+                            std::memmove(pixels + row * window.w, pixels + row * pitch,
+                                         static_cast<size_t>(window.w) * sizeof(*pixels));
+                    gfx_.draw16bitRGBBitmap(window.x, y, pixels, window.w, count);
                 }
                 markDrawn();
             }

--- a/test/native_canvas/main.cpp
+++ b/test/native_canvas/main.cpp
@@ -21,7 +21,7 @@ namespace {
             output.write(value);
     }
 
-    size_t differences(int panelWidth, int panelHeight, int rotation, int size, int textX, int baseline,
+    size_t differences(int panelWidth, int panelHeight, int rows, int rotation, int size, int textX, int baseline,
                        bool fullTextBounds, bool preparedBounds = false, std::string_view text = sample) {
         Arduino_Canvas reference(panelWidth, panelHeight, nullptr);
         reference.begin(GFX_SKIP_OUTPUT_BEGIN);
@@ -34,12 +34,12 @@ namespace {
         const bool reliableInk = text.find('\n') == std::string_view::npos;
 
         const int pitch = (panelWidth + 3) & ~3;
-        Arduino_Canvas strip(pitch, 2, nullptr);
+        Arduino_Canvas strip(pitch, rows, nullptr);
         strip.begin(GFX_SKIP_OUTPUT_BEGIN);
         strip.setRotation(rotation);
         std::vector<uint16_t> assembled(panelWidth * panelHeight, background);
         const int logicalWidth = reference.width(), logicalHeight = reference.height();
-        for (int y = 0; y < panelHeight; y += 2) {
+        for (int y = 0; y < panelHeight; y += rows) {
             int dx = 0, dy = -y;
             switch (rotation) {
             case 1:
@@ -48,10 +48,10 @@ namespace {
                 break;
             case 2:
                 dx = pitch - panelWidth;
-                dy = y - panelHeight + 2;
+                dy = y - panelHeight + rows;
                 break;
             case 3:
-                dx = y - panelHeight + 2;
+                dx = y - panelHeight + rows;
                 dy = 0;
                 break;
             default:
@@ -65,7 +65,7 @@ namespace {
                 || (x1 < strip.width() && y1 < strip.height() && x1 + inkW > 0 && y1 + inkH > 0))
                 drawText(strip, textX + dx, baseline + dy, size, text);
             const uint16_t* pixels = strip.getFramebuffer();
-            for (int row = 0; row < 2; ++row)
+            for (int row = 0; row < std::min(rows, panelHeight - y); ++row)
                 for (int x = 0; x < panelWidth; ++x)
                     assembled[(y + row) * panelWidth + x] = pixels[row * pitch + x];
         }
@@ -79,38 +79,46 @@ namespace {
 
 int main() {
     size_t cases = 0, failed = 0, withoutFix = 0, preparedFailures = 0, newlineFailures = 0, newlineCullingFailures = 0;
-    for (const auto dimensions: std::array<std::array<int, 2>, 3>{{{96, 74}, {98, 76}, {368, 448}}}) {
-        for (int rotation = 0; rotation < 4; ++rotation) {
-            for (int size = 1; size <= 4; ++size) {
-                for (const auto position: std::array<std::array<int, 2>, 4>{{{3, 31}, {4, 32}, {-2, 17}, {17, 55}}}) {
-                    const auto mismatches =
-                        differences(dimensions[0], dimensions[1], rotation, size, position[0], position[1], true);
-                    ++cases;
-                    if (mismatches) {
-                        ++failed;
-                        if (failed <= 8)
-                            std::printf("FAIL %dx%d rotation=%d size=%d x=%d baseline=%d pixels=%zu\n", dimensions[0],
-                                        dimensions[1], rotation, size, position[0], position[1], mismatches);
+    for (const int rows: {2, 16, 32, 64}) {
+        for (const auto dimensions:
+             std::array<std::array<int, 2>, 6>{{{96, 74}, {98, 76}, {368, 448}, {410, 502}, {480, 480}, {450, 600}}}) {
+            for (int rotation = 0; rotation < 4; ++rotation) {
+                for (int size = 1; size <= 4; ++size) {
+                    for (const auto position:
+                         std::array<std::array<int, 2>, 4>{{{3, 31}, {4, 32}, {-2, 17}, {17, 55}}}) {
+                        const auto mismatches = differences(dimensions[0], dimensions[1], rows, rotation, size,
+                                                            position[0], position[1], true);
+                        ++cases;
+                        if (mismatches) {
+                            ++failed;
+                            if (failed <= 8)
+                                std::printf("FAIL %dx%d rotation=%d size=%d x=%d baseline=%d pixels=%zu\n",
+                                            dimensions[0], dimensions[1], rotation, size, position[0], position[1],
+                                            mismatches);
+                        }
+                        withoutFix += differences(dimensions[0], dimensions[1], rows, rotation, size, position[0],
+                                                  position[1], false)
+                                   != 0;
+                        const auto prepared = differences(dimensions[0], dimensions[1], rows, rotation, size,
+                                                          position[0], position[1], true, true);
+                        if (prepared && ++preparedFailures <= 8)
+                            std::printf("PREPARED FAIL %dx%d rotation=%d size=%d x=%d baseline=%d pixels=%zu\n",
+                                        dimensions[0], dimensions[1], rotation, size, position[0], position[1],
+                                        prepared);
+                        constexpr std::string_view multiline = "Aa Gg\nWPM 123 \xd0\x96\xd1\x8f";
+                        newlineFailures += differences(dimensions[0], dimensions[1], rows, rotation, size, position[0],
+                                                       position[1], true, false, multiline)
+                                        != 0;
+                        newlineCullingFailures += differences(dimensions[0], dimensions[1], rows, rotation, size,
+                                                              position[0], position[1], true, true, multiline)
+                                               != 0;
                     }
-                    withoutFix +=
-                        differences(dimensions[0], dimensions[1], rotation, size, position[0], position[1], false) != 0;
-                    const auto prepared =
-                        differences(dimensions[0], dimensions[1], rotation, size, position[0], position[1], true, true);
-                    if (prepared && ++preparedFailures <= 8)
-                        std::printf("PREPARED FAIL %dx%d rotation=%d size=%d x=%d baseline=%d pixels=%zu\n",
-                                    dimensions[0], dimensions[1], rotation, size, position[0], position[1], prepared);
-                    constexpr std::string_view multiline = "Aa Gg\nWPM 123 \xd0\x96\xd1\x8f";
-                    newlineFailures += differences(dimensions[0], dimensions[1], rotation, size, position[0],
-                                                   position[1], true, false, multiline)
-                                    != 0;
-                    newlineCullingFailures += differences(dimensions[0], dimensions[1], rotation, size, position[0],
-                                                          position[1], true, true, multiline)
-                                           != 0;
                 }
             }
         }
     }
-    std::printf("Native Arduino_GFX + Canvas u8g2: %zu cases, %zu failures, %zu prepared-ink failures; "
+    std::printf("Native Arduino_GFX + Canvas u8g2 (2/16/32/64 rows): %zu cases, %zu failures, %zu prepared-ink "
+                "failures; "
                 "%zu cases fail without full text bounds\n",
                 cases, failed, preparedFailures, withoutFix);
     std::printf("Native newline: %zu failures; %zu failures with prepared-ink culling\n", newlineFailures,

--- a/test/native_canvas/run.py
+++ b/test/native_canvas/run.py
@@ -1,4 +1,4 @@
-"""Compare the installed native Arduino_GFX u8g2 decoder on full and two-row canvases.
+"""Compare the installed native Arduino_GFX u8g2 decoder on full and partial canvases.
 
 Run from any directory after installing firmware dependencies:
     python test/native_canvas/run.py

--- a/test/test_amoled_render/Panel.h
+++ b/test/test_amoled_render/Panel.h
@@ -2,8 +2,12 @@
 
 #include <Arduino_GFX_Library.h>
 #include <vector>
+#include "board/BoardConfig.h"
 
 namespace testgfx {
+    constexpr int transfersFor(int rows) {
+        return (rows + Board::Config::DISPLAY_BUFFER_ROWS - 1) / Board::Config::DISPLAY_BUFFER_ROWS;
+    }
     class Panel final : public Arduino_GFX {
     public:
         Panel(int16_t w = 368, int16_t h = 448, uint16_t initial = 0) :
@@ -11,11 +15,13 @@ namespace testgfx {
                 pixels(static_cast<size_t>(w) * h, initial) {}
 
         void draw16bitRGBBitmap(int16_t x, int16_t y, uint16_t* data, int16_t w, int16_t h) override {
-            if (x < 0 || y < 0 || w <= 0 || h != 2 || ((x | y | w | h) & 1) || x + w > width() || y + h > height()) {
+            if (x < 0 || y < 0 || w <= 0 || h <= 0 || h > Board::Config::DISPLAY_BUFFER_ROWS || ((x | y | w | h) & 1)
+                || x + w > width() || y + h > height()) {
                 ++invalidWindows;
                 return;
             }
             ++transfers;
+            pixelsTransferred += w * h;
             for (int row = 0; row < h; ++row)
                 std::copy_n(data + row * w, w, pixels.data() + (y + row) * width() + x);
         }
@@ -29,6 +35,7 @@ namespace testgfx {
 
         std::vector<uint16_t> pixels;
         int transfers = 0;
+        int pixelsTransferred = 0;
         int invalidWindows = 0;
         int panelRotations = 0;
     };

--- a/test/test_amoled_render/interaction_tests.cpp
+++ b/test/test_amoled_render/interaction_tests.cpp
@@ -98,7 +98,7 @@ namespace {
         const auto cards = screens::watch::carousel(screens::detail::tabContent(ui));
         int cardTransfers = 0;
         for (const auto rect: cards)
-            cardTransfers += ui.paintBounds(rect).w / 2;
+            cardTransfers += testgfx::transfersFor(ui.paintBounds(rect).w);
         draw();
         TEST_ASSERT_EQUAL(screens::Action::None, touch(true, 280, 100));
         TEST_ASSERT_EQUAL(screens::Action::None, touch(true, 160, 100));

--- a/test/test_amoled_render/paint_slice_tests.cpp
+++ b/test/test_amoled_render/paint_slice_tests.cpp
@@ -20,19 +20,20 @@ namespace {
             });
             TEST_ASSERT_NOT_NULL(canvas);
             const int pitch = rotation & 1 ? canvas->height() : canvas->width();
+            const int rows = rotation & 1 ? canvas->width() : canvas->height();
             constexpr int windowWidth = 8;
             const ui::Rect region = rotation & 1 ? ui::Rect{4, 6, 2, windowWidth} : ui::Rect{4, 6, windowWidth, 2};
             const uint16_t background = ui.color(ui::themes::Background);
             for (int pass = 0; pass < 2; ++pass) {
-                const std::vector<uint16_t> before(canvas->getFramebuffer(), canvas->getFramebuffer() + pitch * 2);
+                const std::vector<uint16_t> before(canvas->getFramebuffer(), canvas->getFramebuffer() + pitch * rows);
                 const int transfers = panel.transfers;
                 int callbacks = 0;
                 ui.paint(region, [&](Arduino_GFX& output, ui::Rect local) {
                     ++callbacks;
-                    for (int row = 0; row < 2; ++row) {
+                    for (int row = 0; row < rows; ++row) {
                         for (int x = 0; x < pitch; ++x) {
                             const int index = row * pitch + x;
-                            TEST_ASSERT_EQUAL_UINT16(x < windowWidth ? background : before[index],
+                            TEST_ASSERT_EQUAL_UINT16(row < 2 && x < windowWidth ? background : before[index],
                                                      canvas->getFramebuffer()[index]);
                         }
                     }

--- a/test/test_amoled_render/standby_tests.cpp
+++ b/test/test_amoled_render/standby_tests.cpp
@@ -105,8 +105,8 @@ namespace {
                 screen.draw(ui);
                 const int transfers = panel.transfers - before;
                 // A seeded maze adds only its tiny starting cell to the one full-panel clear.
-                TEST_ASSERT_GREATER_OR_EQUAL(panel.height() / 2, transfers);
-                TEST_ASSERT_LESS_THAN(panel.height(), transfers);
+                TEST_ASSERT_GREATER_OR_EQUAL(testgfx::transfersFor(panel.height()), transfers);
+                TEST_ASSERT_LESS_OR_EQUAL(testgfx::transfersFor(panel.height()) + 2, transfers);
                 for (const uint16_t pixel: panel.pixels)
                     TEST_ASSERT_NOT_EQUAL(stale, pixel);
             }

--- a/test/test_amoled_render/test_main.cpp
+++ b/test/test_amoled_render/test_main.cpp
@@ -54,9 +54,9 @@ namespace {
         }
     }
 
-    void test_two_rows_rotate_without_rotating_panel() {
+    void test_bands_rotate_without_rotating_panel() {
         for (int rotation = 0; rotation < 4; ++rotation) {
-            testgfx::Panel panel(36, 28);
+            testgfx::Panel panel(36, 98);
             ui::Context ui(panel);
             ui.setOrientation(static_cast<ui::Orientation>(rotation));
             const ui::Rect region{0, 0, ui.width(), ui.height()};
@@ -65,15 +65,16 @@ namespace {
                     for (int x = 0; x < region.w; ++x)
                         output.drawPixel(local.x + x, local.y + y, ink(x, y));
             });
-            for (int y = 0; y < 28; ++y)
+            for (int y = 0; y < panel.height(); ++y)
                 for (int x = 0; x < 36; ++x) {
-                    const auto [lx, ly] = logicalPoint(x, y, 36, 28, rotation);
+                    const auto [lx, ly] = logicalPoint(x, y, panel.width(), panel.height(), rotation);
                     TEST_ASSERT_EQUAL_UINT16(ink(lx, ly), panel.at(x, y));
                 }
             TEST_ASSERT_EQUAL(0, panel.panelRotations);
             TEST_ASSERT_EQUAL(0, panel.invalidWindows);
             TEST_ASSERT_EQUAL(0, panel.writes);
-            TEST_ASSERT_EQUAL(14, panel.transfers);
+            TEST_ASSERT_EQUAL(testgfx::transfersFor(panel.height()), panel.transfers);
+            TEST_ASSERT_EQUAL(panel.width() * panel.height(), panel.pixelsTransferred);
         }
     }
 
@@ -81,8 +82,9 @@ namespace {
         constexpr uint16_t sentinel = 0xDEAD;
         for (int rotation = 0; rotation < 4; ++rotation) {
             for (const ui::Rect requested:
-                 {ui::Rect{3, 5, 11, 9}, ui::Rect{-3, -5, 15, 17}, ui::Rect{23, 23, 25, 21}}) {
-                testgfx::Panel panel(36, 28, sentinel);
+                 {ui::Rect{3, 5, 11, 9}, ui::Rect{-3, -5, 15, 17}, ui::Rect{23, 23, 25, 21}, ui::Rect{7, 9, 79, 91},
+                  ui::Rect{-5, -7, 81, 111}, ui::Rect{85, 81, 41, 41}}) {
+                testgfx::Panel panel(92, 106, sentinel);
                 ui::Context ui(panel);
                 ui.setOrientation(static_cast<ui::Orientation>(rotation));
                 const ui::Rect region = ui.paintBounds(requested);
@@ -91,9 +93,9 @@ namespace {
                         for (int x = 0; x < region.w; ++x)
                             output.drawPixel(local.x + x, local.y + y, ink(x, y));
                 });
-                for (int y = 0; y < 28; ++y)
-                    for (int x = 0; x < 36; ++x) {
-                        const auto [lx, ly] = logicalPoint(x, y, 36, 28, rotation);
+                for (int y = 0; y < panel.height(); ++y)
+                    for (int x = 0; x < panel.width(); ++x) {
+                        const auto [lx, ly] = logicalPoint(x, y, panel.width(), panel.height(), rotation);
                         const bool inside =
                             lx >= region.x && ly >= region.y && lx < region.x + region.w && ly < region.y + region.h;
                         TEST_ASSERT_EQUAL_UINT16(inside ? ink(lx - region.x, ly - region.y) : sentinel, panel.at(x, y));
@@ -137,7 +139,7 @@ namespace {
 int main() {
     UNITY_BEGIN();
     RUN_TEST(test_rotated_touch_matches_the_painted_pixel);
-    RUN_TEST(test_two_rows_rotate_without_rotating_panel);
+    RUN_TEST(test_bands_rotate_without_rotating_panel);
     RUN_TEST(test_partial_odd_and_clipped_regions_preserve_neighbours);
     RUN_TEST(test_widget_updates_use_aligned_payloads_and_keep_siblings);
     runAmoledReaderTests();

--- a/test/test_amoled_render/widget_tests.cpp
+++ b/test/test_amoled_render/widget_tests.cpp
@@ -21,14 +21,14 @@ namespace {
                     output.fillRect(local.x + 2 + state * 4, local.y + 2, 2, 2, 0xffff);
                 });
                 ui.endFrame();
-                TEST_ASSERT_EQUAL((rotation & 1 ? rect.w : rect.h) / 2, panel.transfers - transfers);
+                TEST_ASSERT_EQUAL(testgfx::transfersFor(rotation & 1 ? rect.w : rect.h), panel.transfers - transfers);
                 TEST_ASSERT_EQUAL(4, std::ranges::count(panel.pixels, uint16_t{0xffff}));
             }
             ui.beginFrame(1);
             const int transfers = panel.transfers;
             TEST_ASSERT_TRUE(ui.redraw(rect, 2));
             ui.endFrame();
-            TEST_ASSERT_EQUAL((rotation & 1 ? rect.w : rect.h) / 2, panel.transfers - transfers);
+            TEST_ASSERT_EQUAL(testgfx::transfersFor(rotation & 1 ? rect.w : rect.h), panel.transfers - transfers);
             TEST_ASSERT_EQUAL(0, std::ranges::count(panel.pixels, uint16_t{0xffff}));
             TEST_ASSERT_EQUAL(0, panel.invalidWindows);
         }
@@ -138,7 +138,7 @@ namespace {
             draw(0);
             const int transfers = panel.transfers;
             draw(1);
-            TEST_ASSERT_EQUAL(rect.h / 2, panel.transfers - transfers);
+            TEST_ASSERT_EQUAL(testgfx::transfersFor(rect.h), panel.transfers - transfers);
             TEST_ASSERT_EQUAL(0, panel.invalidWindows);
             TEST_ASSERT_EQUAL(0, panel.writes);
         }
@@ -163,7 +163,7 @@ namespace {
             const auto original = panel.pixels;
             const int transfers = panel.transfers;
             draw(false);
-            TEST_ASSERT_EQUAL(rect.h / 2, panel.transfers - transfers);
+            TEST_ASSERT_EQUAL(testgfx::transfersFor(rect.h), panel.transfers - transfers);
             TEST_ASSERT_TRUE(original != panel.pixels);
             expectBackground(panel, rect, ui.color(ui::themes::Background));
             TEST_ASSERT_EQUAL(0, panel.invalidWindows);
@@ -185,13 +185,13 @@ namespace {
         ui.beginFrame(1);
         ui.button(first, "First");
         ui.endFrame();
-        TEST_ASSERT_EQUAL(second.h / 2, panel.transfers - transfers);
+        TEST_ASSERT_EQUAL(testgfx::transfersFor(second.h), panel.transfers - transfers);
         expectBackground(panel, second, ui.color(ui::themes::Background));
         transfers = panel.transfers;
         ui.beginFrame(1);
         ui.button(moved, "First");
         ui.endFrame();
-        TEST_ASSERT_EQUAL((first.h + moved.h) / 2, panel.transfers - transfers);
+        TEST_ASSERT_EQUAL(testgfx::transfersFor(first.h) + testgfx::transfersFor(moved.h), panel.transfers - transfers);
         expectBackground(panel, first, ui.color(ui::themes::Background));
         TEST_ASSERT_EQUAL(0, panel.invalidWindows);
         TEST_ASSERT_EQUAL(0, panel.writes);


### PR DESCRIPTION
## Changes
- Reuse the existing Arduino_Canvas with 32 physical rows, selected in each AMOLED board config. LCD 3.49 and C6 continue to compile without this partial canvas.
- Paint and transfer short final bands correctly in all four orientations; clear only active slices and pack narrow rectangles in place.
- Expand the existing regressions and update the hardware/release notes. No new renderer, full-screen framebuffer, second pixel buffer, driver changes, or UI layout changes.

On AMOLED 1.8 this uses 23 KiB and reduces a full-screen paint from 224 callbacks/bitmap transfers to 14, without increasing its pixel payload. This is a work-count reduction, not a measured hardware frame rate. RSVP dirty bounds remain conservative to avoid clipping shaped glyphs and phantom words.

## Validation
- All 267 native tests passed across regular/watch UI, aligned rendering, board wiring and light sleep.
- Real Arduino_GFX raster comparisons passed all 1,536 cases at 2/16/32/64 rows across all AMOLED sizes, four rotations, clipping and final partial bands.
- Compiled-object inspection confirms the partial canvas is absent from LCD 3.49.
- All eight production firmware environments built successfully locally. Physical speed and touch feel still need tester confirmation.