### PR TITLE
fix(ui): inset watch layouts and correct AMOLED 1.8 orientation

### DIFF
--- a/docs/releases/v0.1.2.md
+++ b/docs/releases/v0.1.2.md
@@ -1,0 +1,14 @@
+# v0.1.2
+
+- Flip the AMOLED 1.8 V1/V2 landscape orientation, with matching touch coordinates
+  and the opposite orientation for left-handed use.
+- Inset watch menus, navigation, and horizontal reader controls to leave room for
+  rounded display corners. The AMOLED 1.8 uses a 24-pixel inset; text sizes stay unchanged.
+- Move the watch RSVP previous-sentence arrow and its touch target to the lower
+  right, above the footer. Left-handed use mirrors it to the lower left.
+- Keep page-reading edge gestures and the regular LCD 3.49 layout unchanged.
+- Remove unused panel-memory rotation constants. No framebuffer or rendering
+  layer is added.
+
+Host checks cover watch layouts, reader geometry, and aligned AMOLED rendering.
+The physical corner clearance and orientation still need tester confirmation.

--- a/src/platforms/waveshare_amoled_18/WaveshareAmoled18.h
+++ b/src/platforms/waveshare_amoled_18/WaveshareAmoled18.h
@@ -48,7 +48,6 @@ namespace WaveshareAmoled18::DisplayWiring {
     constexpr uint16_t kPanelWidth = 368;
     constexpr uint16_t kPanelHeight = 448;
     constexpr size_t kTxChunkBytes = 32 * 1024;
-    constexpr bool kPanelMemoryRotated180 = Version::kPanelMemoryRotated180;
     constexpr uint16_t kPanelColumnOffset = Version::kPanelColumnOffset;
     constexpr uint16_t kPanelRowOffset = Version::kPanelRowOffset;
     constexpr ui::Orientation kDefaultUiOrientation = Version::kDefaultUiOrientation;

--- a/src/platforms/waveshare_amoled_18/v1/WaveshareAmoled18Version.h
+++ b/src/platforms/waveshare_amoled_18/v1/WaveshareAmoled18Version.h
@@ -8,10 +8,9 @@ namespace WaveshareAmoled18::Version {
     constexpr const char* kBoardLabel = "Waveshare ESP32-S3-Touch-AMOLED-1.8 V1";
     constexpr const char* kOtaAssetName = "rsvp-nano-esp32-s3-touch-amoled-1.8-ota.bin";
 
-    constexpr bool kPanelMemoryRotated180 = true;
     constexpr uint16_t kPanelColumnOffset = 0;
     constexpr uint16_t kPanelRowOffset = 0;
-    constexpr ui::Orientation kDefaultUiOrientation = ui::Orientation::Landscape;
+    constexpr ui::Orientation kDefaultUiOrientation = ui::Orientation::LandscapeFlipped;
 
     constexpr uint8_t kTouchAddress = 0x38;
 

--- a/src/platforms/waveshare_amoled_18/v2/WaveshareAmoled18Version.h
+++ b/src/platforms/waveshare_amoled_18/v2/WaveshareAmoled18Version.h
@@ -9,10 +9,9 @@ namespace WaveshareAmoled18::Version {
     constexpr const char* kOtaAssetName = "rsvp-nano-esp32-s3-touch-amoled-1.8-v2-ota.bin";
 
     // Transfers retain native panel axes; the UI's strip composition supplies quarter-turn rotation.
-    constexpr bool kPanelMemoryRotated180 = false;
     constexpr uint16_t kPanelColumnOffset = 16;
     constexpr uint16_t kPanelRowOffset = 0;
-    constexpr ui::Orientation kDefaultUiOrientation = ui::Orientation::Landscape;
+    constexpr ui::Orientation kDefaultUiOrientation = ui::Orientation::LandscapeFlipped;
 
     constexpr uint8_t kTouchAddress = 0x15;
 

--- a/src/platforms/waveshare_amoled_206/WaveshareAmoled206.h
+++ b/src/platforms/waveshare_amoled_206/WaveshareAmoled206.h
@@ -43,7 +43,6 @@ namespace WaveshareAmoled206::DisplayWiring {
     constexpr uint16_t kColumnOffset = 22;
     constexpr uint16_t kRowOffset = 0;
     constexpr size_t kTxChunkBytes = 32 * 1024;
-    constexpr bool kPanelMemoryRotated180 = false;
     constexpr ui::Orientation kDefaultUiOrientation = ui::Orientation::Landscape;
 } // namespace WaveshareAmoled206::DisplayWiring
 

--- a/src/platforms/waveshare_amoled_216/WaveshareAmoled216.h
+++ b/src/platforms/waveshare_amoled_216/WaveshareAmoled216.h
@@ -41,7 +41,6 @@ namespace WaveshareAmoled216::DisplayWiring {
     constexpr uint16_t kPanelWidth = 480;
     constexpr uint16_t kPanelHeight = 480;
     constexpr size_t kTxChunkBytes = 32 * 1024;
-    constexpr bool kPanelMemoryRotated180 = false;
     constexpr ui::Orientation kDefaultUiOrientation = ui::Orientation::Landscape;
 } // namespace WaveshareAmoled216::DisplayWiring
 

--- a/src/platforms/waveshare_amoled_241/WaveshareAmoled241.h
+++ b/src/platforms/waveshare_amoled_241/WaveshareAmoled241.h
@@ -30,7 +30,6 @@ namespace WaveshareAmoled241::DisplayWiring {
     constexpr uint16_t kPanelColumnOffset = 16;
     constexpr uint16_t kPanelRowOffset = 0;
     constexpr size_t kTxChunkBytes = 48 * 1024;
-    constexpr bool kPanelMemoryRotated180 = false;
     constexpr ui::Orientation kDefaultUiOrientation = ui::Orientation::Landscape;
 } // namespace WaveshareAmoled241::DisplayWiring
 

--- a/src/platforms/waveshare_lcd_349/WaveshareLcd349.h
+++ b/src/platforms/waveshare_lcd_349/WaveshareLcd349.h
@@ -39,7 +39,6 @@ namespace WaveshareLcd349::DisplayWiring {
     constexpr uint16_t kPanelWidth = 172;
     constexpr uint16_t kPanelHeight = 640;
     constexpr size_t kTxChunkBytes = 16 * 1024;
-    constexpr bool kPanelMemoryRotated180 = true;
     constexpr ui::Orientation kDefaultUiOrientation = ui::Orientation::LandscapeFlipped;
 } // namespace WaveshareLcd349::DisplayWiring
 

--- a/src/ui/screens/ReaderAppearanceLayout.h
+++ b/src/ui/screens/ReaderAppearanceLayout.h
@@ -4,7 +4,7 @@
 
 namespace screens::appearanceLayout {
     struct Layout {
-        ui::Rect back, page, reset, size, font, preview, dialPage;
+        ui::Rect bounds, back, page, reset, size, font, preview, dialPage;
         std::array<ui::Rect, 4> dials;
         bool pagedDials;
     };
@@ -16,15 +16,16 @@ namespace screens::appearanceLayout {
         ui::Rect footerFormat, batteryFormat, preview;
     };
 
-    inline Chrome chrome(ui::Context& ui, bool leftHanded, ui::Rect page) {
+    inline Chrome chrome(ui::Context& ui, bool leftHanded, const Layout& controls) {
         Chrome out{};
         out.reader = readerLayout::horizontalChrome(ui.width(), ui.height(), leftHanded, 96);
         auto& reader = out.reader;
-        reader.chapter.y = reader.progress.y = ui.height() - 44;
+        const auto page = controls.page;
+        reader.chapter.y = reader.progress.y = controls.size.y;
         reader.chapter.h = reader.progress.h = 40;
         out.footerFormat = {static_cast<int16_t>(leftHanded ? reader.progress.x + reader.progress.w + 4
                                                             : reader.progress.x - 48),
-                            static_cast<int16_t>(ui.height() - 44), 44, 40};
+                            reader.progress.y, 44, 40};
         if (leftHanded) {
             const int16_t right = reader.chapter.x + reader.chapter.w;
             reader.chapter.x = out.footerFormat.x + out.footerFormat.w + 4;
@@ -32,15 +33,15 @@ namespace screens::appearanceLayout {
         } else {
             reader.chapter.w = out.footerFormat.x - 4 - reader.chapter.x;
         }
-        out.batteryFormat = {static_cast<int16_t>(reader.battery.x - 48), 2, 44, 40};
+        out.batteryFormat = {static_cast<int16_t>(reader.battery.x - 48), page.y, 44, 40};
         if (out.batteryFormat.x < page.x + page.w + 4) {
             reader.battery.y += 44;
             out.batteryFormat.y += 44;
         }
         // Reserve the longest label format; neither element moves when its text or visibility changes.
         reader.batteryParts = ui.batteryLayout(reader.battery, "0.00V");
-        const int16_t top = std::max<int16_t>(44, reader.battery.y + reader.battery.h + 2);
-        out.preview = {0, top, ui.width(), static_cast<int16_t>(ui.height() - 44 - top)};
+        const int16_t top = std::max<int16_t>(page.y + page.h + 2, reader.battery.y + reader.battery.h + 2);
+        out.preview = {controls.bounds.x, top, controls.bounds.w, static_cast<int16_t>(reader.chapter.y - top)};
         return out;
     }
 

--- a/src/ui/screens/ReaderAppearanceScreen.cpp
+++ b/src/ui/screens/ReaderAppearanceScreen.cpp
@@ -47,7 +47,7 @@ namespace screens {
             state = ui::Context::combine(state, value);
         const auto footer =
             readerLayout::progressText(ui, reading ? settings::FooterMetric::percentage : config.footerMetric, 42, 132);
-        const auto chrome = appearanceLayout::chrome(ui, config.leftHanded, layout.page);
+        const auto chrome = appearanceLayout::chrome(ui, config.leftHanded, layout);
         const ui::Rect preview = ui.paintBounds(typography ? layout.preview : chrome.preview);
         if (showPreview && ui.redraw(preview, state, true)) {
             const auto arrows = typography ? ui::TextLayout{} : readerLayout::prepareArrows(ui, config, reading, true);

--- a/src/ui/screens/ReaderLayout.cpp
+++ b/src/ui/screens/ReaderLayout.cpp
@@ -39,10 +39,7 @@ namespace screens::readerLayout {
         const bool visible = settings::visible(settings.arrowsVisibility, reading);
         if (!visible && !ghostHidden)
             return;
-        const auto rect = horizontalChrome(ui.width(), ui.height(), settings.leftHanded).arrows;
-        const int16_t height = std::max(rect.h, wordHeight);
-        const ui::Rect area =
-            ui.paintBounds({rect.x, static_cast<int16_t>((ui.height() - height) / 2), rect.w, height});
+        const auto area = ui.paintBounds(arrowArea(ui.width(), ui.height(), settings.leftHanded, wordHeight));
         const auto text = prepareArrows(ui, settings, reading, ghostHidden);
         ui.paint(area, [&](Arduino_GFX& output, ui::Rect target) {
             drawArrows(ui, output, settings, reading, text, wordHeight, static_cast<int16_t>(target.x - area.x),
@@ -64,12 +61,10 @@ namespace screens::readerLayout {
         const bool visible = settings::visible(settings.arrowsVisibility, reading);
         if (!visible && !ghostHidden)
             return;
-        auto rect = horizontalChrome(ui.width(), ui.height(), settings.leftHanded).arrows;
-        const int16_t height = std::max(rect.h, wordHeight);
+        auto rect = arrowArea(ui.width(), ui.height(), settings.leftHanded, wordHeight);
         rect.x += offsetX;
         rect.y += offsetY;
-        output.fillRect(rect.x, static_cast<int16_t>((ui.height() - height) / 2 + offsetY), rect.w, height,
-                        ui.color(ui::themes::Background));
+        output.fillRect(rect.x, rect.y, rect.w, rect.h, ui.color(ui::themes::Background));
         ui.drawText(output, text, ui.blend(ui::themes::Muted, visible ? 255 : 64), offsetX, offsetY);
     }
 

--- a/src/ui/screens/ReaderLayout.h
+++ b/src/ui/screens/ReaderLayout.h
@@ -15,7 +15,8 @@ namespace screens::readerLayout {
     ui::Rect portraitFeedbackRect();
     ui::Rect portraitBottomStrip(int16_t width, int16_t height);
     ui::Rect portraitPreviousRect(int16_t width, int16_t height, bool leftHanded);
-    uint16_t previousSentenceTapWidth();
+    ui::Rect previousSentenceRect(int16_t width, int16_t height, bool leftHanded, bool pageView);
+    ui::Rect arrowArea(int16_t width, int16_t height, bool leftHanded, int16_t wordHeight);
 
     struct HorizontalChrome {
         ui::Rect chapter, progress, battery, arrows;

--- a/src/ui/screens/ReaderScreen.cpp
+++ b/src/ui/screens/ReaderScreen.cpp
@@ -761,9 +761,10 @@ namespace screens {
         }
         if (ui::contains(batteryRect(width_, height_), x, y))
             return false;
-        return settings_.leftHanded
-                 ? x <= previousSentenceTapWidth()
-                 : x >= static_cast<uint16_t>(std::max<int16_t>(0, width_ - previousSentenceTapWidth()));
+        return ui::contains(readerLayout::previousSentenceRect(width_, height_, settings_.leftHanded,
+                                                               settings_.mode == settings::ReadingMode::page
+                                                                   || pagePreview_),
+                            x, y);
     }
 
     void ReaderScreen::handleTouch(ui::Context& ui, uint32_t nowMs, Preferences& preferences,

--- a/src/ui/screens/regular/ReaderAppearanceLayout.cpp
+++ b/src/ui/screens/regular/ReaderAppearanceLayout.cpp
@@ -3,6 +3,7 @@
 namespace screens::appearanceLayout {
     Layout make(int16_t width, int16_t height) {
         Layout out{};
+        out.bounds = {0, 0, width, height};
         out.back = {4, 2, 44, 40};
         out.page = {52, 2, 144, 40};
         out.reset = {200, 2, 72, 40};

--- a/src/ui/screens/regular/ReaderLayout.cpp
+++ b/src/ui/screens/regular/ReaderLayout.cpp
@@ -40,8 +40,15 @@ namespace screens::readerLayout {
         return {static_cast<int16_t>(leftHanded ? 8 : width - 48), static_cast<int16_t>(height - 40), 40, 30};
     }
 
-    uint16_t previousSentenceTapWidth() {
-        return 112;
+    ui::Rect previousSentenceRect(int16_t width, int16_t height, bool leftHanded, bool) {
+        return {static_cast<int16_t>(leftHanded ? 0 : std::max<int>(0, width - 112)), 0,
+                std::min<int16_t>(width, leftHanded ? 113 : 112), height};
+    }
+    ui::Rect arrowArea(int16_t width, int16_t height, bool leftHanded, int16_t wordHeight) {
+        auto rect = horizontalChrome(width, height, leftHanded).arrows;
+        rect.h = std::max(rect.h, wordHeight);
+        rect.y = (height - rect.h) / 2;
+        return rect;
     }
     HorizontalChrome horizontalChrome(int16_t width, int16_t height, bool leftHanded, int16_t footerWidth) {
         const int16_t y = height - 26;

--- a/src/ui/screens/watch/Layout.h
+++ b/src/ui/screens/watch/Layout.h
@@ -4,6 +4,11 @@
 #include "ui/screens/ScreenCommon.h"
 
 namespace screens::watch {
+    constexpr ui::Rect contentBounds(int16_t width, int16_t height) {
+        const int16_t inset = std::clamp<int16_t>(std::min(width, height) / 15, 12, 28) & ~1;
+        return {inset, inset, static_cast<int16_t>(width - 2 * inset), static_cast<int16_t>(height - 2 * inset)};
+    }
+
     inline uint8_t textSize(const ui::Context& ui) {
         return std::min(ui.width(), ui.height()) < 240 ? 2 : 3;
     }

--- a/src/ui/screens/watch/ReaderAppearanceLayout.cpp
+++ b/src/ui/screens/watch/ReaderAppearanceLayout.cpp
@@ -1,17 +1,22 @@
 #include "ui/screens/ReaderAppearanceLayout.h"
+#include "ui/screens/watch/Layout.h"
 
 namespace screens::appearanceLayout {
     Layout make(int16_t width, int16_t height) {
+        const auto area = watch::contentBounds(width, height);
+        width = area.w;
+        height = area.h;
         Layout out{};
+        out.bounds = area;
         out.back = {4, 2, 44, 40};
         out.page = {52, 2, std::clamp<int16_t>(width - 132, 44, 144), 40};
         const int16_t resetX = out.page.x + out.page.w + 4;
         out.reset = {resetX, 2, std::min<int16_t>(72, width - resetX - 4), 40};
-        out.size = {4, static_cast<int16_t>(height - 44), std::min<int16_t>(108, width / 2 - 8), 40};
+        out.size = {4, static_cast<int16_t>(height - 42), std::min<int16_t>(108, width / 2 - 8), 40};
         const int16_t fontX = out.size.x + out.size.w + 8;
-        out.font = {fontX, static_cast<int16_t>(height - 44), static_cast<int16_t>(width - fontX - 4), 40};
+        out.font = {fontX, static_cast<int16_t>(height - 42), static_cast<int16_t>(width - fontX - 4), 40};
         out.preview = {0, static_cast<int16_t>(height / 2 - 44), width, 88};
-        out.pagedDials = height < 300;
+        out.pagedDials = height < 300 && width >= 260;
         if (out.pagedDials) {
             out.page.w = 44;
             out.reset = {static_cast<int16_t>(width - 76), 2, 72, 40};
@@ -28,6 +33,15 @@ namespace screens::appearanceLayout {
             for (int i = 0; i < 4; ++i)
                 out.dials[i] = {static_cast<int16_t>(left + (i % 2) * (dialWidth + 12)),
                                 static_cast<int16_t>(i < 2 ? 46 : height / 2 + 46), dialWidth, dialHeight};
+        }
+        for (auto* rect: {&out.back, &out.page, &out.reset, &out.size, &out.font, &out.preview, &out.dialPage})
+            if (rect->w > 0 && rect->h > 0) {
+                rect->x += area.x;
+                rect->y += area.y;
+            }
+        for (auto& rect: out.dials) {
+            rect.x += area.x;
+            rect.y += area.y;
         }
         return out;
     }

--- a/src/ui/screens/watch/ReaderLayout.cpp
+++ b/src/ui/screens/watch/ReaderLayout.cpp
@@ -1,11 +1,18 @@
 #include "ui/screens/ReaderLayout.h"
 #include "fonts/RFont4Format.h"
+#include "ui/screens/watch/Layout.h"
 
 namespace screens::readerLayout {
     size_t pageStrikeIndex() {
         return RFont4::kCompactStrikeIndex - 1;
     }
     ui::Rect readingArea(int16_t width, int16_t height, bool verticalPage) {
+        if (!verticalPage) {
+            auto area = watch::contentBounds(width, height);
+            area.y += 42;
+            area.h = std::max<int16_t>(0, area.h - 84);
+            return area;
+        }
         const int16_t left = verticalPage ? portraitTopStrip(height).h : 0;
         const int16_t right = verticalPage ? portraitBottomStrip(height, width).h : 0;
         return {left, 42, static_cast<int16_t>(std::max<int>(0, width - left - right)),
@@ -32,20 +39,28 @@ namespace screens::readerLayout {
     ui::Rect portraitPreviousRect(int16_t width, int16_t height, bool leftHanded) {
         return {static_cast<int16_t>(leftHanded ? 6 : width - 54), static_cast<int16_t>(height - 40), 48, 36};
     }
-    uint16_t previousSentenceTapWidth() {
-        return 48;
+    ui::Rect previousSentenceRect(int16_t width, int16_t height, bool leftHanded, bool pageView) {
+        if (pageView)
+            return {static_cast<int16_t>(leftHanded ? 0 : std::max<int>(0, width - 48)), 0,
+                    std::min<int16_t>(width, leftHanded ? 49 : 48), height};
+        return horizontalChrome(width, height, leftHanded).arrows;
+    }
+    ui::Rect arrowArea(int16_t width, int16_t height, bool leftHanded, int16_t) {
+        return horizontalChrome(width, height, leftHanded).arrows;
     }
 
     HorizontalChrome horizontalChrome(int16_t width, int16_t height, bool leftHanded, int16_t) {
-        const int16_t footerWidth = width / 3;
-        const int16_t y = height - 42;
+        const auto area = watch::contentBounds(width, height);
+        const int16_t footerWidth = area.w / 3;
+        const int16_t batteryWidth = std::min<int16_t>(104, area.w - 48);
+        const int16_t y = area.y + area.h - 42;
         return {
-            .chapter = {static_cast<int16_t>(leftHanded ? footerWidth + 12 : 8), y,
-                        static_cast<int16_t>(width - footerWidth - 20), 40},
-            .progress = {static_cast<int16_t>(leftHanded ? 8 : width - footerWidth - 8), y, footerWidth, 40},
-            .battery = {static_cast<int16_t>(width - 112), 0, 104, 42},
-            .arrows = {static_cast<int16_t>(leftHanded ? 8 : width - 52), static_cast<int16_t>(height / 2 - 22), 44,
-                       44},
+            .chapter = {static_cast<int16_t>(area.x + (leftHanded ? footerWidth + 4 : 0)), y,
+                        static_cast<int16_t>(area.w - footerWidth - 4), 40},
+            .progress = {static_cast<int16_t>(leftHanded ? area.x : area.x + area.w - footerWidth), y, footerWidth, 40},
+            .battery = {static_cast<int16_t>(area.x + area.w - batteryWidth), area.y, batteryWidth, 42},
+            .arrows = {static_cast<int16_t>(leftHanded ? area.x : area.x + area.w - 44), static_cast<int16_t>(y - 44),
+                       44, 44},
             .textSize = static_cast<uint8_t>(height < 240 ? 2 : 3),
         };
     }

--- a/src/ui/screens/watch/ScreenCommon.cpp
+++ b/src/ui/screens/watch/ScreenCommon.cpp
@@ -10,11 +10,13 @@ namespace screens::detail {
                               : active >= Screen::FocusTimers && active <= Screen::FocusSession ? 3
                                                                                                 : 2;
         const int16_t height = ui.height() < 240 ? 36 : 48;
-        const int16_t y = ui.height() - height - 6;
-        const int16_t small = (ui.width() - 28) / 6;
-        int16_t x = 8;
+        const auto area = content(ui);
+        const int16_t y = area.y + area.h - height;
+        const int16_t available = area.w - 12;
+        const int16_t small = available / 6;
+        int16_t x = area.x;
         for (size_t i = 0; i < faces.size(); ++i) {
-            const int16_t width = i == selected ? static_cast<int16_t>(ui.width() - 28 - small * 3) : small;
+            const int16_t width = i == selected ? static_cast<int16_t>(available - small * 3) : small;
             const ui::Rect rect{x, y, width, height};
             // Dock colors are stable face identities; the text still follows the active theme.
             const std::array<uint16_t, 4> colors{ui.color(ui::themes::Accent), ui::themes::rgb565(190, 130, 32),
@@ -27,7 +29,7 @@ namespace screens::detail {
     }
 
     ui::Rect content(ui::Context& ui) {
-        return {8, 8, static_cast<int16_t>(ui.width() - 16), static_cast<int16_t>(ui.height() - 16)};
+        return watch::contentBounds(ui.width(), ui.height());
     }
 
     ui::Rect tabContent(ui::Context& ui) {

--- a/test/native_watch_preview/Arduino.h
+++ b/test/native_watch_preview/Arduino.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <cmath>
+#include <cstdlib>
+#include "../support/Arduino.h"
+class __FlashStringHelper;
+using std::max;
+using std::min;
+inline int8_t pgm_read_sbyte(const void* address) {
+    return static_cast<int8_t>(pgm_read_byte(address));
+}

--- a/test/native_watch_preview/Arduino_GFX_Library.h
+++ b/test/native_watch_preview/Arduino_GFX_Library.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// Use the real rasterizer in the host preview, not the unit-test drawing stub.
+#include <Arduino_GFX.h>
+#include <canvas/Arduino_Canvas.h>

--- a/test/native_watch_preview/main.cpp
+++ b/test/native_watch_preview/main.cpp
@@ -1,0 +1,79 @@
+#include <canvas/Arduino_Canvas.h>
+#include <cstdio>
+#include <filesystem>
+#include "ui/screens/ChaptersScreen.h"
+#include "ui/screens/ReaderLayout.h"
+#include "ui/screens/ScreenCommon.h"
+
+int main(int argc, char** argv) {
+    if (argc != 2)
+        return 1;
+    std::filesystem::create_directories(argv[1]);
+    for (const auto [width, height]: {std::pair{320, 172}, {448, 368}, {502, 410}, {480, 480}, {600, 450}}) {
+        Arduino_Canvas panel(width, height, nullptr);
+        if (!panel.begin(GFX_SKIP_OUTPUT_BEGIN))
+            return 1;
+        ui::Context ui(panel);
+        const auto theme = ui::themes::defaultTheme();
+        ui.setTheme(theme);
+        settings::ReadingSettings reading;
+        settings::PacingSettings pacing;
+        screens::ChaptersScreen chapters;
+        ReadingSession reader;
+        const std::array<ChapterMarker, 3> markers{
+            {{"A Parade in Erhenrang", 0}, {"The Place Inside the Blizzard", 5}, {"The Escape", 10}}};
+        for (auto screen: {screens::Screen::Read, screens::Screen::Settings, screens::Screen::Device,
+                           screens::Screen::ReadingSettings, screens::Screen::PacingSettings, screens::Screen::Chapters,
+                           screens::Screen::Ota, screens::Screen::Reader}) {
+            ui.beginFrame(static_cast<uint8_t>(screen));
+            switch (screen) {
+            case screens::Screen::Read:
+                screens::read(ui, "The Left Hand of Darkness", "Ursula K. Le Guin", 42, screen);
+                break;
+            case screens::Screen::Settings:
+                screens::settings(ui, screen);
+                break;
+            case screens::Screen::Device:
+                screens::device(ui, true, 18, settings::NvsEncryptionState::Available, screen);
+                break;
+            case screens::Screen::ReadingSettings:
+                screens::readingSettings(ui, reading, screen);
+                break;
+            case screens::Screen::PacingSettings:
+                screens::pacingSettings(ui, pacing, screen);
+                break;
+            case screens::Screen::Chapters:
+                chapters.draw(ui, markers, reader, reading, 0, screen);
+                break;
+            case screens::Screen::Ota:
+                screens::ota(ui, "v0.1.1", screen);
+                break;
+            case screens::Screen::Reader: {
+                const Board::Power::BatteryState battery{{true, 3.9f, 64}, 0, false};
+                screens::readerLayout::chrome(ui, {.chapter = "Chapter 12", .footer = "42%", .batteryLabel = "64%"},
+                                              reading, battery);
+                screens::readerLayout::drawArrows(ui, reading, false, 68);
+                break;
+            }
+            default:
+                break;
+            }
+            ui.endFrame();
+            const auto file = std::filesystem::path{argv[1]}
+                            / (std::to_string(width) + "x" + std::to_string(height) + "-"
+                               + std::to_string(static_cast<int>(screen)) + ".ppm");
+            auto* output = std::fopen(file.string().c_str(), "wb");
+            if (!output)
+                return 1;
+            std::fprintf(output, "P6\n%d %d\n255\n", width, height);
+            for (int i = 0; i < width * height; ++i) {
+                const uint16_t pixel = panel.getFramebuffer()[i];
+                const unsigned char rgb[]{static_cast<unsigned char>(((pixel >> 11) & 31) * 255 / 31),
+                                          static_cast<unsigned char>(((pixel >> 5) & 63) * 255 / 63),
+                                          static_cast<unsigned char>((pixel & 31) * 255 / 31)};
+                std::fwrite(rgb, 1, 3, output);
+            }
+            std::fclose(output);
+        }
+    }
+}

--- a/test/native_watch_preview/run.py
+++ b/test/native_watch_preview/run.py
@@ -1,0 +1,59 @@
+"""Capture watch screens using firmware layouts, UI font, and the real Arduino_GFX rasterizer.
+
+Host-only canvases do not change device rendering or allocate device memory.
+Requires the installed PlatformIO native and AMOLED 1.8 V2 dependencies.
+Run `pio test -e native_watch_test` first; use --native-build if its build directory was overridden.
+"""
+
+import argparse
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+PROJECT = Path(__file__).resolve().parents[2]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--compiler", default=shutil.which("g++"))
+    parser.add_argument("--native-build", type=Path, default=PROJECT / ".pio/build/native_watch_test")
+    args = parser.parse_args()
+    if not args.compiler:
+        parser.error("Use --compiler to select a native g++ compiler")
+    support = Path(__file__).resolve().parent
+    library = PROJECT / ".pio/libdeps/waveshare_esp32s3_touch_amoled_18_v2/GFX Library for Arduino/src"
+    sources = [
+        "ui/Ui.cpp", "ui/Controls.cpp", "ui/Icons.cpp", "ui/Theme.cpp", "ui/Localization.generated.cpp",
+        "localization/LocalePack.cpp", "text/LocaleTag.cpp", "text/BidiText.cpp", "text/TextShaping.cpp",
+        "reader/ReadingLoop.cpp", "ui/screens/watch/ScreenCommon.cpp", "ui/screens/watch/ReadScreen.cpp",
+        "ui/screens/watch/SettingsScreen.cpp", "ui/screens/watch/DeviceScreen.cpp",
+        "ui/screens/watch/ReadingSettingsScreen.cpp", "ui/screens/watch/PacingSettingsScreen.cpp",
+        "ui/screens/watch/ChaptersScreen.cpp", "ui/screens/watch/OtaScreen.cpp",
+        "ui/screens/ReaderLayout.cpp", "ui/screens/watch/ReaderLayout.cpp",
+    ]
+    includes = [support, PROJECT / "test/native_canvas", PROJECT / "test/support", PROJECT / "src", library,
+                PROJECT / "lib/HarfBuzz/upstream/src", PROJECT / "lib/SheenBidi/upstream/Headers",
+                PROJECT / ".pio/libdeps/native_watch_test/glaze/include"]
+    libraries = []
+    for name in ("HarfBuzz", "SheenBidi"):
+        archive = next(args.native_build.glob(f"lib*/lib{name}.a"), None)
+        if archive is None:
+            parser.error(f"Missing {name} archive in {args.native_build}; build native_watch_test first")
+        libraries.append(archive)
+    with tempfile.TemporaryDirectory(prefix="rsvpnano-watch-preview-") as temp:
+        executable = Path(temp) / "watch-preview.exe"
+        subprocess.run([
+            args.compiler, "-std=c++23", "-O1", "-funsigned-char", "-ffunction-sections", "-fdata-sections",
+            "-DGLZ_DEFAULT_OPTIMIZATION_SIZE", "-DGLZ_DISABLE_ALWAYS_INLINE",
+            *[f"-I{path}" for path in includes], str(support / "main.cpp"),
+            *[str(PROJECT / "src" / file) for file in sources],
+            str(library / "Arduino_G.cpp"), str(library / "Arduino_GFX.cpp"),
+            str(library / "canvas/Arduino_Canvas.cpp"), *map(str, libraries), "-Wl,--gc-sections", "-o", str(executable),
+        ], check=True)
+        subprocess.run([str(executable), str(args.output.resolve())], check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/support/AppearanceChecks.h
+++ b/test/support/AppearanceChecks.h
@@ -25,7 +25,7 @@ namespace appearanceChecks {
             const auto chrome = screens::readerLayout::horizontalChrome(width, height, leftHanded);
             for (const auto rect: {chrome.chapter, chrome.progress, chrome.battery, chrome.arrows})
                 inside(rect);
-            const auto editor = screens::appearanceLayout::chrome(ui, leftHanded, layout.page);
+            const auto editor = screens::appearanceLayout::chrome(ui, leftHanded, layout);
             for (const auto rect:
                  {editor.reader.chapter, editor.reader.progress, editor.reader.batteryParts.icon,
                   editor.reader.batteryParts.label, editor.footerFormat, editor.batteryFormat, editor.preview})
@@ -97,7 +97,7 @@ namespace appearanceChecks {
         settings.chapterVisibility = settings.progressVisibility = settings::Visibility::never;
         settings.batteryLabelVisibility = settings::Visibility::paused;
         const auto chrome = screens::readerLayout::horizontalChrome(640, 172, false);
-        const ui::Rect preview{0, 44, 640, 84};
+        const auto preview = screens::readerLayout::readingArea(640, 172, false);
         const Board::Power::BatteryState battery{{true, 3.9f, 64}, 0, false};
         for (const auto format: {settings::BatteryLabel::percentage, settings::BatteryLabel::voltage,
                                  settings::BatteryLabel::timeRemaining}) {
@@ -133,15 +133,15 @@ namespace appearanceChecks {
         gfx.cleared.clear();
         screens::readerLayout::drawArrows(ui, settings, false, 68);
         TEST_ASSERT_EQUAL(1, gfx.cleared.size());
-        TEST_ASSERT_EQUAL(68, gfx.cleared.back().h);
-        TEST_ASSERT_EQUAL(52, gfx.cleared.back().y);
+        const auto arrows = screens::readerLayout::arrowArea(640, 172, false, 68);
+        TEST_ASSERT_EQUAL(arrows.h, gfx.cleared.back().h);
+        TEST_ASSERT_EQUAL(arrows.y, gfx.cleared.back().y);
         settings.arrowsVisibility = settings::Visibility::never;
         gfx.cleared.clear();
         screens::readerLayout::drawArrows(ui, settings, false, 68);
         TEST_ASSERT_TRUE(gfx.cleared.empty());
 
-        const auto editor =
-            screens::appearanceLayout::chrome(ui, false, screens::appearanceLayout::make(640, 172).page);
+        const auto editor = screens::appearanceLayout::chrome(ui, false, screens::appearanceLayout::make(640, 172));
         ui.invalidate();
         const auto editorFrame = [&](std::string_view footer, std::string_view label) {
             ui.beginFrame(2);

--- a/test/test_ui/test_main.cpp
+++ b/test/test_ui/test_main.cpp
@@ -1646,6 +1646,20 @@ void test_hourglass_source_follows_glass_and_fallen_sand_settles_at_base() {
 
 void test_appearance_controls_fit_lcd() {
     appearanceChecks::layout(640, 172);
+    const auto arrow = screens::readerLayout::arrowArea(640, 172, false, 68);
+    TEST_ASSERT_EQUAL(588, arrow.x);
+    TEST_ASSERT_EQUAL(52, arrow.y);
+    TEST_ASSERT_EQUAL(68, arrow.h);
+    const auto tap = screens::readerLayout::previousSentenceRect(640, 172, false, false);
+    TEST_ASSERT_EQUAL(528, tap.x);
+    TEST_ASSERT_EQUAL(0, tap.y);
+    TEST_ASSERT_EQUAL(172, tap.h);
+    Arduino_GFX gfx(640, 172);
+    ui::Context ui(gfx);
+    const auto editor = screens::appearanceLayout::chrome(ui, false, screens::appearanceLayout::make(640, 172));
+    TEST_ASSERT_EQUAL(0, editor.preview.x);
+    TEST_ASSERT_EQUAL(640, editor.preview.w);
+    TEST_ASSERT_EQUAL(128, editor.reader.chapter.y);
 }
 
 int main(int, char**) {

--- a/test/test_watch_ui/test_main.cpp
+++ b/test/test_watch_ui/test_main.cpp
@@ -28,6 +28,7 @@ namespace {
     public:
         using Arduino_GFX::Arduino_GFX;
         bool outside = false;
+        bool cornerClipped = false;
         void record(int x, int y, int w, int h) {
             outside |= w < 0 || h < 0 || x < 0 || y < 0 || x + w > width() || y + h > height();
         }
@@ -36,13 +37,19 @@ namespace {
         }
         void fillRoundRect(int16_t x, int16_t y, int16_t w, int16_t h, int16_t, uint16_t) override {
             record(x, y, w, h);
+            recordControl(x, y, w, h);
         }
         void drawRoundRect(int16_t x, int16_t y, int16_t w, int16_t h, int16_t, uint16_t) override {
             record(x, y, w, h);
+            recordControl(x, y, w, h);
         }
         void drawLine(int16_t x, int16_t y, int16_t x2, int16_t y2, uint16_t) override {
             record(x, y, 1, 1);
             record(x2, y2, 1, 1);
+        }
+        void recordControl(int16_t x, int16_t y, int16_t w, int16_t h) {
+            const auto area = screens::watch::contentBounds(width(), height());
+            cornerClipped |= x < area.x || y < area.y || x + w > area.x + area.w || y + h > area.y + area.h;
         }
     };
 
@@ -79,6 +86,7 @@ namespace {
                 }
                 ui.endFrame();
                 TEST_ASSERT_FALSE_MESSAGE(gfx.outside, "watch screen painted outside the physical display");
+                TEST_ASSERT_FALSE_MESSAGE(gfx.cornerClipped, "watch control crossed the rounded-corner inset");
             }
             screens::status(ui, "Preparing book", "The Left Hand of Darkness", "Preparing typography", 64);
             TEST_ASSERT_FALSE(gfx.outside);
@@ -203,6 +211,32 @@ namespace {
         }
     }
 
+    void test_rsvp_arrow_and_touch_target_share_the_safe_lower_corner() {
+        for (const auto size: watchResolutions) {
+            const auto bounds = screens::watch::contentBounds(size.width, size.height);
+            const auto reading = screens::readerLayout::readingArea(size.width, size.height, false);
+            for (const bool left: {false, true}) {
+                const auto chrome = screens::readerLayout::horizontalChrome(size.width, size.height, left);
+                const auto arrow = screens::readerLayout::arrowArea(size.width, size.height, left, 68);
+                const auto tap = screens::readerLayout::previousSentenceRect(size.width, size.height, left, false);
+                TEST_ASSERT_EQUAL(44, arrow.w);
+                TEST_ASSERT_EQUAL(44, arrow.h);
+                TEST_ASSERT_EQUAL(left ? bounds.x : bounds.x + bounds.w - 44, arrow.x);
+                TEST_ASSERT_EQUAL(chrome.chapter.y, arrow.y + arrow.h);
+                TEST_ASSERT_GREATER_OR_EQUAL(reading.y, arrow.y);
+                TEST_ASSERT_LESS_OR_EQUAL(reading.y + reading.h, arrow.y + arrow.h);
+                TEST_ASSERT_EQUAL(arrow.x, tap.x);
+                TEST_ASSERT_EQUAL(arrow.y, tap.y);
+                TEST_ASSERT_EQUAL(arrow.w, tap.w);
+                TEST_ASSERT_EQUAL(arrow.h, tap.h);
+                TEST_ASSERT_FALSE(ui::contains(tap, arrow.x + 22, bounds.y + 42));
+                const auto pageTap = screens::readerLayout::previousSentenceRect(size.width, size.height, left, true);
+                TEST_ASSERT_EQUAL(0, pageTap.y);
+                TEST_ASSERT_EQUAL(size.height, pageTap.h);
+            }
+        }
+    }
+
     void test_dock_reaches_all_four_destinations() {
         constexpr std::array destinations{screens::Screen::Read, screens::Screen::Settings, screens::Screen::Device,
                                           screens::Screen::FocusTimers};
@@ -282,6 +316,7 @@ int main() {
     RUN_TEST(test_rotary_uses_relative_delta_and_clamps);
     RUN_TEST(test_paging_never_exposes_offscreen_hit_targets_and_resets);
     RUN_TEST(test_reader_layout_fits_and_preserves_handedness);
+    RUN_TEST(test_rsvp_arrow_and_touch_target_share_the_safe_lower_corner);
     RUN_TEST(test_dock_reaches_all_four_destinations);
     RUN_TEST(test_chapter_selection_does_not_activate_until_center_tap);
     return UNITY_END();


### PR DESCRIPTION
## Changes

- Inset watch menus and horizontal reader controls for rounded display corners without shrinking text.
- Move the watch RSVP previous-sentence arrow and touch target to the lower-right corner, mirrored for left-handed use.
- Flip the AMOLED 1.8 V1/V2 landscape orientation and remove unused panel-memory rotation declarations.
- Preserve page-reader edge gestures and the regular LCD 3.49 layout.
- Add geometry regressions, a host-only raster preview tool, and v0.1.2 release notes.

## Validation

- 92 native UI, watch UI, and AMOLED rendering checks passed.
- AMOLED 1.8 V1/V2 and LCD 3.49 rev1 firmware builds passed.
- Inspected Settings previews at 448x368 and 320x172 and RSVP controls at 448x368 using the actual UI rasterizer.
- Physical corner clearance and orientation still need tester confirmation.

No additional device framebuffer or rendering layer is introduced.